### PR TITLE
ci: add workflow that runs tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: formal-verify/mcp-server
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: formal-verify/mcp-server/package-lock.json
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that runs the MCP server test suite (unit, integration, property, and MCP protocol tests) on pushes to `main` and PRs targeting `main`

## Test plan
- [ ] Verify workflow runs successfully on this PR
- [ ] Confirm tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)