### PR TITLE
feat: Add difficulty metrics to dafny_verify tool

### DIFF
--- a/formal-verify/mcp-server/src/__tests__/mcp/protocol.test.ts
+++ b/formal-verify/mcp-server/src/__tests__/mcp/protocol.test.ts
@@ -72,8 +72,16 @@ describe("MCP Protocol", () => {
       expect(parsed).toHaveProperty("errors");
       expect(parsed).toHaveProperty("warnings");
       expect(parsed).toHaveProperty("rawOutput");
+      expect(parsed).toHaveProperty("difficulty");
       expect(parsed.success).toBe(true);
       expect(parsed.errors).toEqual([]);
+      expect(parsed.difficulty).toEqual(
+        expect.objectContaining({
+          proofHintCount: expect.any(Number),
+          emptyLemmaBodyCount: expect.any(Number),
+          trivialProof: expect.any(Boolean),
+        })
+      );
     });
   });
 

--- a/formal-verify/mcp-server/src/__tests__/property/extractDifficultyMetrics.prop.test.ts
+++ b/formal-verify/mcp-server/src/__tests__/property/extractDifficultyMetrics.prop.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { extractDifficultyMetrics } from "../../tools/verify.js";
+
+describe("extractDifficultyMetrics property tests", () => {
+  it("counts are always non-negative", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        expect(result.proofHintCount).toBeGreaterThanOrEqual(0);
+        expect(result.emptyLemmaBodyCount).toBeGreaterThanOrEqual(0);
+      })
+    );
+  });
+
+  it("solverTimeMs is null or >= 0", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        if (result.solverTimeMs !== null) {
+          expect(result.solverTimeMs).toBeGreaterThanOrEqual(0);
+        }
+      })
+    );
+  });
+
+  it("resourceCount is null or >= 0", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        if (result.resourceCount !== null) {
+          expect(result.resourceCount).toBeGreaterThanOrEqual(0);
+        }
+      })
+    );
+  });
+
+  it("no lemma keyword in source means emptyLemmaBodyCount === 0", () => {
+    const noLemmaArb = fc
+      .string()
+      .filter((s) => !s.includes("lemma"));
+
+    fc.assert(
+      fc.property(noLemmaArb, fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        expect(result.emptyLemmaBodyCount).toBe(0);
+      })
+    );
+  });
+
+  it("trivialProof is consistent: true only when proofHintCount === 0", () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        if (result.trivialProof) {
+          expect(result.proofHintCount).toBe(0);
+        }
+      })
+    );
+  });
+
+  it("trivialProof is false when proofHintCount > 0", () => {
+    // Source with at least one assert statement
+    const sourceWithAssert = fc
+      .string()
+      .map((s) => `  assert something;\n${s}`);
+
+    fc.assert(
+      fc.property(sourceWithAssert, fc.string(), (source, output) => {
+        const result = extractDifficultyMetrics(source, output);
+        if (result.proofHintCount > 0) {
+          expect(result.trivialProof).toBe(false);
+        }
+      })
+    );
+  });
+});

--- a/formal-verify/mcp-server/src/__tests__/unit/extractDifficultyMetrics.test.ts
+++ b/formal-verify/mcp-server/src/__tests__/unit/extractDifficultyMetrics.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from "vitest";
+import { extractDifficultyMetrics } from "../../tools/verify.js";
+
+describe("extractDifficultyMetrics", () => {
+  describe("solver time parsing", () => {
+    it("parses solver time from 'finished in X.XXs' pattern", () => {
+      const result = extractDifficultyMetrics(
+        "",
+        "Dafny program verifier finished in 1.23s"
+      );
+      expect(result.solverTimeMs).toBe(1230);
+    });
+
+    it("parses integer seconds", () => {
+      const result = extractDifficultyMetrics(
+        "",
+        "finished in 5s"
+      );
+      expect(result.solverTimeMs).toBe(5000);
+    });
+
+    it("returns null when no time pattern found", () => {
+      const result = extractDifficultyMetrics(
+        "",
+        "Dafny program verifier finished with 1 verified, 0 errors"
+      );
+      expect(result.solverTimeMs).toBeNull();
+    });
+  });
+
+  describe("resource count parsing", () => {
+    it("parses resource count from output", () => {
+      const result = extractDifficultyMetrics(
+        "",
+        "resource count: 12345"
+      );
+      expect(result.resourceCount).toBe(12345);
+    });
+
+    it("parses case-insensitive resource count", () => {
+      const result = extractDifficultyMetrics(
+        "",
+        "Resource Count: 999"
+      );
+      expect(result.resourceCount).toBe(999);
+    });
+
+    it("returns null when no resource count found", () => {
+      const result = extractDifficultyMetrics("", "no resources here");
+      expect(result.resourceCount).toBeNull();
+    });
+  });
+
+  describe("proof hint counting", () => {
+    it("counts assert statements", () => {
+      const source = `
+method Foo() {
+  assert x > 0;
+  assert y < 10;
+}`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.proofHintCount).toBe(2);
+    });
+
+    it("counts calc blocks", () => {
+      const source = `
+lemma CalcExample()
+{
+  calc {
+    1 + 1;
+    == 2;
+  }
+}`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.proofHintCount).toBe(1);
+    });
+
+    it("counts mixed assert and calc", () => {
+      const source = `
+method Foo() {
+  assert x > 0;
+  calc {
+    a;
+    == b;
+  }
+  assert y == z;
+}`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.proofHintCount).toBe(3);
+    });
+
+    it("returns 0 when no proof hints", () => {
+      const source = "method Main() {}";
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.proofHintCount).toBe(0);
+    });
+  });
+
+  describe("empty lemma body detection", () => {
+    it("counts lemmas with empty bodies", () => {
+      const source = `lemma Trivial() {}`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.emptyLemmaBodyCount).toBe(1);
+    });
+
+    it("counts multiple empty lemmas", () => {
+      const source = `
+lemma Foo() {}
+lemma Bar() {}
+lemma Baz() { assert true; }`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.emptyLemmaBodyCount).toBe(2);
+    });
+
+    it("does not count lemmas with content", () => {
+      const source = `lemma NonTrivial() { assert x > 0; }`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.emptyLemmaBodyCount).toBe(0);
+    });
+
+    it("counts lemmas with whitespace-only bodies", () => {
+      const source = `lemma Trivial() {   }`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.emptyLemmaBodyCount).toBe(1);
+    });
+  });
+
+  describe("trivialProof derivation", () => {
+    it("is true when no hints and empty lemma bodies exist", () => {
+      const source = `lemma Trivial() {}`;
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.trivialProof).toBe(true);
+    });
+
+    it("is true when no hints and solver time < 2000ms", () => {
+      const source = "method Main() {}";
+      const result = extractDifficultyMetrics(
+        source,
+        "finished in 0.5s"
+      );
+      expect(result.trivialProof).toBe(true);
+    });
+
+    it("is false when hints are present even with fast time", () => {
+      const source = `
+method Foo() {
+  assert x > 0;
+}`;
+      const result = extractDifficultyMetrics(
+        source,
+        "finished in 0.1s"
+      );
+      expect(result.trivialProof).toBe(false);
+    });
+
+    it("is false when no hints and no time info and no empty lemmas", () => {
+      const source = "method Main() {}";
+      const result = extractDifficultyMetrics(source, "");
+      expect(result.trivialProof).toBe(false);
+    });
+
+    it("is false when solver time >= 2000ms and no empty lemmas", () => {
+      const source = "method Main() {}";
+      const result = extractDifficultyMetrics(
+        source,
+        "finished in 3.0s"
+      );
+      expect(result.trivialProof).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles empty source and empty output", () => {
+      const result = extractDifficultyMetrics("", "");
+      expect(result.solverTimeMs).toBeNull();
+      expect(result.resourceCount).toBeNull();
+      expect(result.proofHintCount).toBe(0);
+      expect(result.emptyLemmaBodyCount).toBe(0);
+      expect(result.trivialProof).toBe(false);
+    });
+  });
+});

--- a/formal-verify/mcp-server/src/__tests__/unit/verify.test.ts
+++ b/formal-verify/mcp-server/src/__tests__/unit/verify.test.ts
@@ -60,6 +60,14 @@ describe("dafnyVerify", () => {
 
     expect(result.success).toBe(true);
     expect(result.errors).toEqual([]);
+    expect(result).toHaveProperty("difficulty");
+    expect(result.difficulty).toEqual(
+      expect.objectContaining({
+        proofHintCount: expect.any(Number),
+        emptyLemmaBodyCount: expect.any(Number),
+        trivialProof: expect.any(Boolean),
+      })
+    );
   });
 
   it("returns failure when exitCode is 0 but errors are parsed", async () => {
@@ -105,6 +113,13 @@ describe("dafnyVerify", () => {
     expect(result.errors).toEqual([
       "Verification timed out after 120 seconds",
     ]);
+    expect(result.difficulty).toEqual({
+      solverTimeMs: null,
+      resourceCount: null,
+      proofHintCount: 0,
+      emptyLemmaBodyCount: 0,
+      trivialProof: false,
+    });
   });
 
   it("includes raw output from stdout and stderr", async () => {

--- a/formal-verify/mcp-server/src/index.ts
+++ b/formal-verify/mcp-server/src/index.ts
@@ -13,7 +13,7 @@ export function createServer(): McpServer {
 
   server.tool(
     "dafny_verify",
-    "Verify Dafny source code. Writes source to a temp file, runs `dafny verify`, and returns structured results with errors/warnings.",
+    "Verify Dafny source code. Writes source to a temp file, runs `dafny verify`, and returns structured results with errors/warnings and difficulty metrics (solver time, resource count, proof hint count, trivial proof detection).",
     {
       source: z.string().describe("Dafny source code to verify"),
     },

--- a/formal-verify/mcp-server/src/tools/verify.ts
+++ b/formal-verify/mcp-server/src/tools/verify.ts
@@ -7,11 +7,61 @@ interface VerifyInput {
   source: string;
 }
 
+export interface DifficultyMetrics {
+  solverTimeMs: number | null;
+  resourceCount: number | null;
+  proofHintCount: number;
+  emptyLemmaBodyCount: number;
+  trivialProof: boolean;
+}
+
 interface VerifyOutput {
   success: boolean;
   errors: string[];
   warnings: string[];
   rawOutput: string;
+  difficulty: DifficultyMetrics;
+}
+
+export function extractDifficultyMetrics(
+  source: string,
+  rawOutput: string
+): DifficultyMetrics {
+  // Parse solver time from patterns like "finished in X.XXs"
+  let solverTimeMs: number | null = null;
+  const timeMatch = rawOutput.match(/finished\s+in\s+(\d+(?:\.\d+)?)s/);
+  if (timeMatch) {
+    solverTimeMs = Math.round(parseFloat(timeMatch[1]) * 1000);
+  }
+
+  // Parse resource count from "resource count: NNN" or similar
+  let resourceCount: number | null = null;
+  const resourceMatch = rawOutput.match(/resource\s+count:\s*(\d+)/i);
+  if (resourceMatch) {
+    resourceCount = parseInt(resourceMatch[1], 10);
+  }
+
+  // Count proof hints: lines matching assert or calc blocks
+  const proofHintCount = (source.match(/^\s*(assert\s|calc\s*\{)/gm) || [])
+    .length;
+
+  // Count empty lemma bodies
+  const emptyLemmaBodyCount = (
+    source.match(/lemma\s+\w+[^{]*\{\s*\}/g) || []
+  ).length;
+
+  // Determine if proof is trivial
+  const trivialProof =
+    (proofHintCount === 0 && emptyLemmaBodyCount > 0) ||
+    (proofHintCount === 0 && solverTimeMs !== null && solverTimeMs < 2000);
+
+  return {
+    solverTimeMs,
+    resourceCount,
+    proofHintCount,
+    emptyLemmaBodyCount,
+    trivialProof,
+  };
 }
 
 export function parseDafnyOutput(
@@ -49,17 +99,27 @@ export async function dafnyVerify(input: VerifyInput): Promise<VerifyOutput> {
         errors: ["Verification timed out after 120 seconds"],
         warnings: [],
         rawOutput: result.stdout + "\n" + result.stderr,
+        difficulty: {
+          solverTimeMs: null,
+          resourceCount: null,
+          proofHintCount: 0,
+          emptyLemmaBodyCount: 0,
+          trivialProof: false,
+        },
       };
     }
 
     const { errors, warnings } = parseDafnyOutput(result.stdout, result.stderr);
     const success = result.exitCode === 0 && errors.length === 0;
+    const rawOutput = (result.stdout + "\n" + result.stderr).trim();
+    const difficulty = extractDifficultyMetrics(input.source, rawOutput);
 
     return {
       success,
       errors,
       warnings,
-      rawOutput: (result.stdout + "\n" + result.stderr).trim(),
+      rawOutput,
+      difficulty,
     };
   } finally {
     await removeTempDir(tempDir);


### PR DESCRIPTION
## Summary
- Adds `DifficultyMetrics` interface and `extractDifficultyMetrics()` function to the `dafny_verify` MCP tool, parsing solver time, resource count, proof hint count, and empty lemma bodies from Dafny output
- Returns a `difficulty` field in verification results with a `trivialProof` flag that identifies proofs requiring no hints and completing quickly
- Includes comprehensive unit tests (20 cases) and property-based tests (6 properties via fast-check)

## Test plan
- [x] All 128 existing + new unit/property/integration/MCP tests pass (`npm test`)
- [x] E2E tests skipped (require Docker, not available in CI for this unit)
- [x] Existing verify.test.ts and protocol.test.ts updated to assert `difficulty` field shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)