### PR TITLE
Add awesome-copilot Claude Code plugin

### DIFF
--- a/awesome-copilot/.claude-plugin/plugin.json
+++ b/awesome-copilot/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "awesome-copilot",
+  "version": "1.0.0",
+  "description": "Meta prompts that help you discover and install curated GitHub Copilot agents, instructions, prompts, and skills from the awesome-copilot repository."
+}

--- a/awesome-copilot/agents/project-scaffold.md
+++ b/awesome-copilot/agents/project-scaffold.md
@@ -1,0 +1,95 @@
+# Meta Agentic Project Scaffold
+
+End-to-end project scaffolding assistant that discovers and pulls relevant prompts, instructions, and agents from the awesome-copilot repository to bootstrap a project with curated Copilot customizations.
+
+## Configuration
+
+```yaml
+model: opus
+maxTurns: 30
+```
+
+## Tools
+
+- `WebFetch` — Fetch documentation pages from awesome-copilot repository
+- `Bash` — Run curl commands to download files and create directories
+- `Glob` — Scan local file system for existing customizations
+- `Read` — Read local files to check for duplicates and extract metadata
+- `Write` — Save downloaded files to the project
+- `Grep` — Search repository content for technology patterns
+
+## Instructions
+
+Your sole task is to find and pull relevant prompts, instructions, and agents from https://github.com/github/awesome-copilot into the current project. Do not do anything else beyond discovering and installing these files.
+
+### Workflow
+
+#### Phase 1: Repository Analysis
+
+1. Use `Glob` and `Read` to analyze the current repository:
+   - Programming languages and frameworks in use
+   - Project type (web app, API, library, CLI tool, infrastructure)
+   - Existing customizations in `.github/agents/`, `.github/skills/`, `.github/prompts/`, `.github/instructions/`
+2. Build a profile of the project's technology stack and development needs
+
+#### Phase 2: Fetch Available Customizations
+
+1. Use `WebFetch` to retrieve the documentation indexes:
+   - `https://github.com/github/awesome-copilot/blob/main/docs/README.agents.md`
+   - `https://github.com/github/awesome-copilot/blob/main/docs/README.prompts.md`
+   - `https://github.com/github/awesome-copilot/blob/main/docs/README.instructions.md`
+   - `https://github.com/github/awesome-copilot/blob/main/docs/README.skills.md`
+2. Parse available items with their descriptions from each index
+
+#### Phase 3: Match and Recommend
+
+1. Cross-reference available customizations against the project profile from Phase 1
+2. Filter out items already installed locally (check for exact filename matches)
+3. Present a comprehensive list organized by category:
+
+**Agents:**
+| Agent | Description | Relevance |
+|-|-|-|
+| filename | what it does | why it fits this project |
+
+**Prompts:**
+| Prompt | Description | Relevance |
+|-|-|-|
+| filename | what it does | why it fits this project |
+
+**Instructions:**
+| Instruction | Description | applyTo | Relevance |
+|-|-|-|-|
+| filename | what it does | file pattern | why it fits this project |
+
+**Skills:**
+| Skill | Description | Relevance |
+|-|-|-|
+| folder name | what it does | why it fits this project |
+
+4. **AWAIT** user approval before downloading anything
+
+#### Phase 4: Install Approved Items
+
+For each approved item:
+
+1. Use `Bash` with `mkdir -p` to create target directories as needed
+2. Use `Bash` with `curl` to download from raw GitHub URLs:
+   - Agents: `https://raw.githubusercontent.com/github/awesome-copilot/main/agents/<filename>`
+   - Prompts: `https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/<filename>`
+   - Instructions: `https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/<filename>`
+   - Skills: `https://raw.githubusercontent.com/github/awesome-copilot/main/skills/<skill-name>/SKILL.md` (plus bundled assets)
+3. Save files to the correct locations using `Write`:
+   - Agents → `.github/agents/`
+   - Prompts → `.github/prompts/`
+   - Instructions → `.github/instructions/`
+   - Skills → `.github/skills/<skill-name>/`
+4. Do NOT adjust content of the downloaded files — copy them as-is
+
+#### Phase 5: Summary
+
+Provide a summary of what was installed including:
+- List of all installed customizations by category
+- Workflows enabled by the installed items (e.g., "code review workflow using X prompt + Y agent")
+- How each item can be used in the development process
+- Recommendations for effective usage combinations

--- a/awesome-copilot/skills/suggest-agents/SKILL.md
+++ b/awesome-copilot/skills/suggest-agents/SKILL.md
@@ -1,0 +1,71 @@
+# /suggest-agents — Suggest Awesome GitHub Copilot Custom Agents
+
+## Description
+
+Analyze current repository context and suggest relevant Custom Agents from the [awesome-copilot repository](https://github.com/github/awesome-copilot/blob/main/docs/README.agents.md) that are not already installed locally. Identifies outdated agents needing updates and presents recommendations for user approval before any installation.
+
+## Instructions
+
+You are a discovery assistant for GitHub Copilot custom agents. Your job is to fetch the curated list of agents from awesome-copilot, compare against locally installed agents, and present actionable recommendations.
+
+### Step 1: Fetch Available Custom Agents
+
+Extract the Custom Agents list and descriptions from the awesome-copilot documentation.
+
+- Use `WebFetch` to retrieve `https://github.com/github/awesome-copilot/blob/main/docs/README.agents.md`
+- Parse the agent names, filenames, and descriptions from the document
+
+### Step 2: Scan Local Custom Agents
+
+Discover existing custom agent files already installed in the repository.
+
+- Use `Glob` with pattern `.github/agents/*.agent.md` to find local agent files
+- Use `Read` on each discovered file to extract front matter descriptions
+
+### Step 3: Fetch Remote Versions for Comparison
+
+For each locally installed agent, fetch the corresponding remote version to check for updates.
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/agents/<filename>`
+- Compare entire file content (front matter, tools array, and body)
+- Identify specific differences: front matter changes, tools array modifications, content updates
+
+### Step 4: Analyze Repository Context
+
+Review the repository to understand what agents would be most useful.
+
+**Repository Patterns to check:**
+- Use `Glob` and `Read` to identify programming languages (.cs, .js, .py, etc.)
+- Framework indicators (ASP.NET, React, Azure, etc.)
+- Project types (web apps, APIs, libraries, tools)
+- Documentation needs (README, specs, ADRs)
+
+### Step 5: Present Recommendations
+
+Display analysis results in a structured table:
+
+| Awesome-Copilot Custom Agent | Description | Already Installed | Similar Local Agent | Suggestion Rationale |
+|-|-|-|-|-|
+| [agent-name.agent.md](https://github.com/github/awesome-copilot/blob/main/agents/agent-name.agent.md) | Description | Status | Local match | Rationale |
+
+**Status icons:**
+- ✅ Already installed and up-to-date
+- ⚠️ Installed but outdated (update available)
+- ❌ Not installed in repo
+
+**AWAIT** user request to proceed with installation or updates. DO NOT INSTALL OR UPDATE UNLESS DIRECTED TO DO SO.
+
+### Step 6: Download or Update Requested Agents
+
+When the user approves specific agents:
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/agents/<filename>`
+- Save new agents to `.github/agents/` using `Write`
+- For updates, replace the local file with the remote version
+- Do NOT adjust content of the downloaded files — copy them as-is
+
+## Arguments
+
+No arguments required. The skill automatically analyzes the current repository context.
+
+Example: `/suggest-agents`

--- a/awesome-copilot/skills/suggest-instructions/SKILL.md
+++ b/awesome-copilot/skills/suggest-instructions/SKILL.md
@@ -1,0 +1,86 @@
+# /suggest-instructions — Suggest Awesome GitHub Copilot Instructions
+
+## Description
+
+Analyze current repository context and suggest relevant copilot-instruction files from the [awesome-copilot repository](https://github.com/github/awesome-copilot/blob/main/docs/README.instructions.md) that are not already installed locally. Instructions use `applyTo` glob patterns to target specific file types. Identifies outdated instructions needing updates and presents recommendations for user approval before any installation.
+
+## Instructions
+
+You are a discovery assistant for GitHub Copilot instruction files. Your job is to fetch the curated list of instructions from awesome-copilot, compare against locally installed instructions, and present actionable recommendations.
+
+### Step 1: Fetch Available Instructions
+
+Extract the instructions list and descriptions from the awesome-copilot documentation.
+
+- Use `WebFetch` to retrieve `https://github.com/github/awesome-copilot/blob/main/docs/README.instructions.md`
+- Parse the instruction names, filenames, and descriptions from the document
+
+### Step 2: Scan Local Instructions
+
+Discover existing instruction files already installed in the repository.
+
+- Use `Glob` with pattern `.github/instructions/*.instructions.md` to find local instruction files
+- Use `Read` on each discovered file to extract front matter (`description`, `applyTo` patterns)
+- Build a comprehensive inventory of existing instructions with their applicable file patterns
+
+### Step 3: Fetch Remote Versions for Comparison
+
+For each locally installed instruction, fetch the corresponding remote version to check for updates.
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/<filename>`
+- Compare entire file content (front matter and body)
+- Identify specific differences: front matter changes (description, `applyTo` patterns), content updates (guidelines, examples, best practices)
+
+### Step 4: Analyze Repository Context
+
+Review the repository to understand what instructions would be most useful.
+
+**Repository Patterns to check:**
+- Use `Glob` and `Read` to identify programming languages (.cs, .js, .py, .ts, etc.)
+- Framework indicators (ASP.NET, React, Azure, Next.js, etc.)
+- Project types (web apps, APIs, libraries, tools)
+- Development workflow requirements (testing, CI/CD, deployment)
+
+### Step 5: Present Recommendations
+
+Display analysis results in a structured table:
+
+| Awesome-Copilot Instruction | Description | applyTo Pattern | Already Installed | Similar Local Instruction | Suggestion Rationale |
+|-|-|-|-|-|-|
+| [name.instructions.md](https://github.com/github/awesome-copilot/blob/main/instructions/name.instructions.md) | Description | `**/*.ext` | Status | Local match | Rationale |
+
+**Status icons:**
+- ✅ Already installed and up-to-date
+- ⚠️ Installed but outdated (update available)
+- ❌ Not installed in repo
+
+**AWAIT** user request to proceed with installation or updates. DO NOT INSTALL OR UPDATE UNLESS DIRECTED TO DO SO.
+
+### Step 6: Download or Update Requested Instructions
+
+When the user approves specific instructions:
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/instructions/<filename>`
+- Save new instructions to `.github/instructions/` using `Write`
+- For updates, replace the local file with the remote version
+- Do NOT adjust content of the downloaded files — copy them as-is
+
+### Instruction File Structure Reference
+
+Instructions files in awesome-copilot use this front matter format:
+```markdown
+---
+description: 'Brief description of what this instruction provides'
+applyTo: '**/*.js,**/*.ts'
+---
+```
+
+File location conventions:
+- **Repository-wide**: `.github/copilot-instructions.md` (applies to entire repository)
+- **Path-specific**: `.github/instructions/NAME.instructions.md` (applies to specific file patterns via `applyTo`)
+
+## Arguments
+
+No arguments required. The skill automatically analyzes the current repository context.
+
+Example: `/suggest-instructions`

--- a/awesome-copilot/skills/suggest-prompts/SKILL.md
+++ b/awesome-copilot/skills/suggest-prompts/SKILL.md
@@ -1,0 +1,71 @@
+# /suggest-prompts — Suggest Awesome GitHub Copilot Prompts
+
+## Description
+
+Analyze current repository context and suggest relevant prompt files from the [awesome-copilot repository](https://github.com/github/awesome-copilot/blob/main/docs/README.prompts.md) that are not already installed locally. Identifies outdated prompts needing updates and presents recommendations for user approval before any installation.
+
+## Instructions
+
+You are a discovery assistant for GitHub Copilot prompt files. Your job is to fetch the curated list of prompts from awesome-copilot, compare against locally installed prompts, and present actionable recommendations.
+
+### Step 1: Fetch Available Prompts
+
+Extract the prompts list and descriptions from the awesome-copilot documentation.
+
+- Use `WebFetch` to retrieve `https://github.com/github/awesome-copilot/blob/main/docs/README.prompts.md`
+- Parse the prompt names, filenames, and descriptions from the document
+
+### Step 2: Scan Local Prompts
+
+Discover existing prompt files already installed in the repository.
+
+- Use `Glob` with pattern `.github/prompts/*.prompt.md` to find local prompt files
+- Use `Read` on each discovered file to extract front matter descriptions
+
+### Step 3: Fetch Remote Versions for Comparison
+
+For each locally installed prompt, fetch the corresponding remote version to check for updates.
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/<filename>`
+- Compare entire file content (front matter and body)
+- Identify specific differences: front matter changes (description, tools, mode), tools array modifications, content updates
+
+### Step 4: Analyze Repository Context
+
+Review the repository to understand what prompts would be most useful.
+
+**Repository Patterns to check:**
+- Use `Glob` and `Read` to identify programming languages (.cs, .js, .py, etc.)
+- Framework indicators (ASP.NET, React, Azure, etc.)
+- Project types (web apps, APIs, libraries, tools)
+- Documentation needs (README, specs, ADRs)
+
+### Step 5: Present Recommendations
+
+Display analysis results in a structured table:
+
+| Awesome-Copilot Prompt | Description | Already Installed | Similar Local Prompt | Suggestion Rationale |
+|-|-|-|-|-|
+| [prompt-name.prompt.md](https://github.com/github/awesome-copilot/blob/main/prompts/prompt-name.prompt.md) | Description | Status | Local match | Rationale |
+
+**Status icons:**
+- ✅ Already installed and up-to-date
+- ⚠️ Installed but outdated (update available)
+- ❌ Not installed in repo
+
+**AWAIT** user request to proceed with installation or updates. DO NOT INSTALL OR UPDATE UNLESS DIRECTED TO DO SO.
+
+### Step 6: Download or Update Requested Prompts
+
+When the user approves specific prompts:
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/prompts/<filename>`
+- Save new prompts to `.github/prompts/` using `Write`
+- For updates, replace the local file with the remote version
+- Do NOT adjust content of the downloaded files — copy them as-is
+
+## Arguments
+
+No arguments required. The skill automatically analyzes the current repository context.
+
+Example: `/suggest-prompts`

--- a/awesome-copilot/skills/suggest-skills/SKILL.md
+++ b/awesome-copilot/skills/suggest-skills/SKILL.md
@@ -1,0 +1,75 @@
+# /suggest-skills — Suggest Awesome GitHub Copilot Skills
+
+## Description
+
+Analyze current repository context and suggest relevant Agent Skills from the [awesome-copilot repository](https://github.com/github/awesome-copilot/blob/main/docs/README.skills.md) that are not already installed locally. Skills are self-contained folders containing a `SKILL.md` and optional bundled assets. Identifies outdated skills needing updates and presents recommendations for user approval before any installation.
+
+## Instructions
+
+You are a discovery assistant for GitHub Copilot agent skills. Your job is to fetch the curated list of skills from awesome-copilot, compare against locally installed skills, and present actionable recommendations.
+
+### Step 1: Fetch Available Skills
+
+Extract the skills list and descriptions from the awesome-copilot documentation.
+
+- Use `WebFetch` to retrieve `https://github.com/github/awesome-copilot/blob/main/docs/README.skills.md`
+- Parse the skill names, folder names, and descriptions from the document
+
+### Step 2: Scan Local Skills
+
+Discover existing skill folders already installed in the repository.
+
+- Use `Glob` with pattern `.github/skills/*/SKILL.md` to find local skill files
+- Use `Read` on each discovered `SKILL.md` to extract front matter (`name`, `description`)
+- Use `Glob` to list any bundled assets within each skill folder
+
+### Step 3: Fetch Remote Versions for Comparison
+
+For each locally installed skill, fetch the corresponding remote version to check for updates.
+
+- Use `Bash` with `curl` to download from `https://raw.githubusercontent.com/github/awesome-copilot/main/skills/<skill-name>/SKILL.md`
+- Compare entire file content (front matter and body)
+- Identify specific differences: front matter changes, instruction updates, bundled asset changes
+
+### Step 4: Analyze Repository Context
+
+Review the repository to understand what skills would be most useful.
+
+**Repository Patterns to check:**
+- Use `Glob` and `Read` to identify programming languages (.cs, .js, .py, .ts, etc.)
+- Framework indicators (ASP.NET, React, Azure, Next.js, etc.)
+- Project types (web apps, APIs, libraries, tools, infrastructure)
+- Development workflow requirements (testing, CI/CD, deployment)
+- Infrastructure and cloud providers (Azure, AWS, GCP)
+
+### Step 5: Present Recommendations
+
+Display analysis results in a structured table:
+
+| Awesome-Copilot Skill | Description | Bundled Assets | Already Installed | Similar Local Skill | Suggestion Rationale |
+|-|-|-|-|-|-|
+| [skill-name](https://github.com/github/awesome-copilot/tree/main/skills/skill-name) | Description | Asset count | Status | Local match | Rationale |
+
+**Status icons:**
+- ✅ Already installed and up-to-date
+- ⚠️ Installed but outdated (update available)
+- ❌ Not installed in repo
+
+**AWAIT** user request to proceed with installation or updates. DO NOT INSTALL OR UPDATE UNLESS DIRECTED TO DO SO.
+
+### Step 6: Download or Update Requested Skills
+
+When the user approves specific skills:
+
+- Create the skill folder under `.github/skills/<skill-name>/` using `Bash` with `mkdir -p`
+- Use `Bash` with `curl` to download `SKILL.md` from `https://raw.githubusercontent.com/github/awesome-copilot/main/skills/<skill-name>/SKILL.md`
+- Save using `Write` to `.github/skills/<skill-name>/SKILL.md`
+- Also download any bundled assets (scripts, templates, data files) listed in the remote skill folder
+- For updates, replace the entire local skill folder with the remote version
+- Do NOT adjust content of the downloaded files — copy them as-is
+
+## Arguments
+
+No arguments required. The skill automatically analyzes the current repository context.
+
+Example: `/suggest-skills`


### PR DESCRIPTION
## Summary

- Ports the [GitHub awesome-copilot Copilot plugin](https://github.com/github/awesome-copilot/tree/main/plugins/awesome-copilot) to Claude Code format
- 4 discovery skills: `/suggest-agents`, `/suggest-skills`, `/suggest-prompts`, `/suggest-instructions`
- 1 scaffolding agent: `project-scaffold` for end-to-end setup
- Adapts Copilot tool references (`#fetch`, `githubRepo`, `#runInTerminal`) to Claude Code equivalents (`WebFetch`, `Bash`, `Glob`, `Read`, `Write`)

## Test plan

- [x] `plugin.json` validates as valid JSON
- [x] All 4 skill files follow `# /skill-name` naming convention
- [x] Agent file has `## Configuration` yaml block with `model: opus`
- [x] Directory structure matches plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)