### PR TITLE
Update docs for multi-plugin marketplace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,21 +1,26 @@
-# Formal Verify
+# Claude Code Plugin Marketplace
 
-Formal verification plugin for Claude Code. Generates provably correct Python/Go code using Dafny as a verification backend.
+A collection of Claude Code plugins. Each plugin is a self-contained directory with its own skills, agents, and optional MCP server.
 
-## Architecture
+## Plugins
+
+### formal-verify (`formal-verify/`)
+
+Formal verification plugin. Generates provably correct Python/Go code using Dafny as a verification backend.
 
 - **MCP server** (`formal-verify/mcp-server/`): TypeScript server exposing three tools — `dafny_verify`, `dafny_compile`, `dafny_cleanup`
 - **Docker isolation**: Dafny 4.11.0 runs in a sandboxed container (no network, 512MB memory, 120s timeout)
-- **Skills** (`formal-verify/skills/`): `/spec-iterate`, `/generate-verified`, `/extract-code`
+- **Skills** (`formal-verify/skills/`): `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`
 - **Orchestrator agent** (`formal-verify/agents/verify-orchestrator.md`): End-to-end workflow automation
 
-## Workflow
+### awesome-copilot (`awesome-copilot/`)
 
-1. User describes a function → `/spec-iterate` generates a verified Dafny specification
-2. `/generate-verified` implements the spec with loop invariants, lemmas, etc.
-3. `/extract-code` compiles to Python or Go, strips Dafny boilerplate, delivers clean output
+Meta prompts for discovering and installing curated GitHub Copilot customizations.
 
-## Development
+- **Skills** (`awesome-copilot/skills/`): `/suggest-agents`, `/suggest-instructions`, `/suggest-prompts`, `/suggest-skills`
+- **Agent** (`awesome-copilot/agents/project-scaffold.md`): End-to-end project scaffolding
+
+## Development — formal-verify
 
 ```bash
 cd formal-verify/mcp-server

--- a/README.md
+++ b/README.md
@@ -1,174 +1,31 @@
-# Formal Verify
+# Claude Code Plugin Marketplace
 
-A Claude Code plugin that enables formal verification of code using [Dafny](https://dafny.org/). Write formally verified specifications, generate implementations that satisfy them, and extract clean Python or Go code — all from within Claude Code.
+A collection of Claude Code plugins for enhanced development workflows.
 
-The key idea: the LLM proposes Dafny specs and implementations, the Dafny verifier acts as a hard correctness gate, and only verified code gets extracted to the target language. No Dafny artifacts are committed — only clean Python/Go output is the deliverable.
+## Plugins
 
-## Prerequisites
+### [formal-verify](./formal-verify/)
 
-- **Docker** — Dafny runs in an isolated container
-- **Node.js** >= 18
-- **Claude Code** with plugin support
+Formal verification for Python/Go via [Dafny](https://dafny.org/). The LLM proposes Dafny specs and implementations, the Dafny verifier acts as a hard correctness gate, and only verified code gets extracted to the target language.
+
+**Skills:** `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`
+**Agent:** `verify-orchestrator`
+**MCP tools:** `dafny_verify`, `dafny_compile`, `dafny_cleanup`
+
+### [awesome-copilot](./awesome-copilot/)
+
+Meta prompts that help you discover and install curated GitHub Copilot agents, instructions, prompts, and skills from the [awesome-copilot repository](https://github.com/github/awesome-copilot).
+
+**Skills:** `/suggest-agents`, `/suggest-instructions`, `/suggest-prompts`, `/suggest-skills`
+**Agent:** `project-scaffold`
 
 ## Installation
 
-1. Build the Docker image:
-
-```bash
-./scripts/build-docker.sh
-```
-
-2. Build the MCP server:
-
-```bash
-cd mcp-server
-npm install
-npm run build
-```
-
-3. Install the plugin:
+Each plugin is self-contained. Point Claude Code at the plugin directory:
 
 ```bash
 claude plugin add /path/to/formal-verify
+claude plugin add /path/to/awesome-copilot
 ```
 
-## Quick Start
-
-The plugin provides three skills that form a verification pipeline:
-
-```
-/spec-iterate  →  /generate-verified  →  /extract-code
-   (spec)           (implement)            (compile)
-```
-
-**1. Draft and verify a specification:**
-
-```
-/spec-iterate "function that returns the maximum element of a non-empty integer array"
-```
-
-The AI drafts a Dafny spec with preconditions and postconditions, then verifies it (up to 5 attempts).
-
-**2. Generate a verified implementation:**
-
-```
-/generate-verified
-```
-
-The AI fills in the implementation body with loop invariants and assertions, verifying until it passes.
-
-**3. Extract clean code:**
-
-```
-/extract-code to python
-```
-
-Compiles the verified Dafny to Python (or Go), strips Dafny runtime boilerplate, and returns clean code ready for integration.
-
-### Orchestrator Agent
-
-For an end-to-end workflow, use the `verify-orchestrator` agent which chains all three phases automatically.
-
-## Skills
-
-### `/spec-iterate` — Specification Refinement
-
-Iteratively drafts and verifies Dafny specifications from a natural language description.
-
-- Analyses the description for Dafny limitations (IO, concurrency, external libs)
-- Drafts a spec with preconditions, postconditions, and invariants
-- Verifies the spec against Dafny (max 5 attempts)
-- Presents the verified spec for approval before proceeding
-
-### `/generate-verified` — Verified Implementation
-
-Generates an implementation body that satisfies an approved specification.
-
-- Fills in the method body with loop invariants, assertions, and lemmas
-- Verifies the full program (max 5 attempts)
-- Warns about post-generation pitfalls (`real` types, Go generics, underscore identifiers)
-
-### `/extract-code` — Compile and Extract
-
-Compiles verified Dafny to Python or Go and strips boilerplate.
-
-- Removes Dafny runtime imports (`_dafny`, `_System`)
-- Excludes generated runtime files
-- Provides type mapping guidance for the target language
-
-## MCP Tools
-
-The plugin exposes three tools to Claude Code via MCP:
-
-| Tool | Description |
-|------|-------------|
-| `dafny_verify` | Verifies Dafny source code and returns structured errors/warnings |
-| `dafny_compile` | Compiles Dafny to Python or Go, stripping boilerplate |
-| `dafny_cleanup` | Removes stale temp directories older than 30 minutes |
-
-All tools run Dafny inside Docker with: 512MB memory, 1 CPU, no network access, and a 120-second timeout.
-
-## Architecture
-
-```
-formal-verify/
-├── mcp-server/                # Node.js/TypeScript MCP server
-│   ├── src/
-│   │   ├── index.ts           # Server entry, tool registration
-│   │   ├── docker.ts          # Docker container execution
-│   │   ├── tempdir.ts         # Temp directory lifecycle
-│   │   └── tools/
-│   │       ├── verify.ts      # dafny_verify tool
-│   │       ├── compile.ts     # dafny_compile tool
-│   │       └── cleanup.ts     # dafny_cleanup tool
-│   ├── src/__tests__/         # Unit, property, integration, MCP, e2e tests
-│   ├── Dockerfile             # Multi-stage Dafny image
-│   └── package.json
-├── skills/                    # Claude Code skills
-│   ├── spec-iterate/          # /spec-iterate
-│   ├── generate-verified/     # /generate-verified
-│   └── extract-code/          # /extract-code
-├── agents/
-│   └── verify-orchestrator.md # End-to-end orchestrator agent
-├── scripts/
-│   ├── build-docker.sh        # Build the Dafny Docker image
-│   └── test-mcp.sh            # MCP server smoke tests
-└── .claude-plugin/
-    └── plugin.json            # Plugin configuration
-```
-
-## Testing
-
-```bash
-cd mcp-server
-
-# Unit, property, integration, and MCP tests
-npm test
-
-# Watch mode
-npm run test:watch
-
-# End-to-end tests (requires Docker and built image)
-npm run test:e2e
-```
-
-The test suite includes:
-
-- **Unit tests** — Individual functions (parsing, boilerplate stripping, exclusion logic)
-- **Property-based tests** — Fast-check generators for edge case discovery
-- **Integration tests** — Multi-function workflows (file collection, temp directories)
-- **MCP protocol tests** — Server contract verification
-- **End-to-end tests** — Full Docker integration with real Dafny verification
-
-## Known Limitations
-
-- **IO / Networking** — Cannot be formally verified; requires `{:extern}` stubs
-- **Concurrency** — Dafny verifies sequential correctness only
-- **External libraries** — Calls to external libraries are trust boundaries
-- **Go generics** — Type erasure to `interface{}`; may need manual type assertions
-- **Dafny `real` type** — Compiles to `_dafny.BigRational`, not native floats
-- **Mutable state** — Supported but harder to verify; functional design preferred
-
-## Configuration
-
-The Docker image name defaults to `formal-verify-dafny:latest` and can be overridden via the `DAFNY_DOCKER_IMAGE` environment variable in `plugin.json`.
+See each plugin's README for prerequisites and setup details.

--- a/formal-verify/README.md
+++ b/formal-verify/README.md
@@ -65,6 +65,15 @@ Compile verified Dafny to Python or Go, with boilerplate stripped.
 /extract-code to go
 ```
 
+#### `/lightweight-verify` — Lightweight Verification Alternatives
+
+For functions where full formal verification is overkill, generate lightweight verification artifacts: design-by-contract assertions, property-based tests, or documented runtime invariant checks.
+
+```
+/lightweight-verify "function that returns the maximum element of a non-empty integer list" python
+/lightweight-verify "binary search on a sorted array returning the index or -1" go
+```
+
 ### Orchestrator Agent
 
 For end-to-end workflows, use the `verify-orchestrator` agent which chains all three skills:


### PR DESCRIPTION
## Summary
- Rewrite root README as a marketplace overview listing both `formal-verify` and `awesome-copilot` plugins
- Update CLAUDE.md to reflect the multi-plugin repository structure
- Add missing `/lightweight-verify` skill to `formal-verify/README.md`

## Test plan
- [ ] Verify all links in README resolve correctly
- [ ] Confirm CLAUDE.md accurately describes both plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)