### PR TITLE
Add marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "nicholls",
+  "owner": {
+    "name": "nicholls"
+  },
+  "metadata": {
+    "description": "A collection of Claude Code plugins for enhanced development workflows."
+  },
+  "plugins": [
+    {
+      "name": "crosscheck",
+      "source": "./crosscheck",
+      "description": "Crosscheck Claude's code with Dafny formal verification for Python/Go"
+    },
+    {
+      "name": "awesome-copilot",
+      "source": "./awesome-copilot",
+      "description": "Meta prompts that help you discover and install curated GitHub Copilot agents, instructions, prompts, and skills from the awesome-copilot repository."
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ Meta prompts that help you discover and install curated GitHub Copilot agents, i
 
 ## Installation
 
-Each plugin is self-contained. Point Claude Code at the plugin directory:
+Add the marketplace, then install plugins:
 
 ```bash
-claude --plugin-dir ./crosscheck
-claude --plugin-dir ./awesome-copilot
+# Add the marketplace
+claude plugin marketplace add nicholls/claude-code-marketplace
+
+# Install plugins
+claude plugin install crosscheck@nicholls
+claude plugin install awesome-copilot@nicholls
 ```
 
 See each plugin's README for prerequisites and setup details.


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` to make the repo a valid Claude Code plugin marketplace
- Update README installation instructions to use marketplace-based commands (`claude plugin marketplace add` / `claude plugin install`)

## Test plan
- [ ] Run `claude plugin validate .` from repo root to confirm valid marketplace
- [ ] Test `claude plugin marketplace add nicholls/claude-code-marketplace` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)