### PR TITLE
Add semiformal plugin manifest

### DIFF
--- a/semiformal/.claude-plugin/plugin.json
+++ b/semiformal/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "semiformal",
+  "version": "1.0.0",
+  "description": "Semi-formal reasoning skills that structure Claude's code analysis with explicit premises, execution traces, and formal conclusions — preventing unsupported claims and improving accuracy on code verification, fault localization, and question answering tasks."
+}


### PR DESCRIPTION
## Summary
- Adds `semiformal/.claude-plugin/plugin.json` with plugin manifest for the new semiformal reasoning plugin
- Pure skills/agents plugin (no MCP server), following the same convention as `awesome-copilot`

## Test plan
- [x] Verified JSON is valid and matches existing plugin manifest structure
- [ ] Downstream units will add skills and agents to this plugin scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)