### PR TITLE
feat: add /reason skill for semi-formal code reasoning

### DIFF
--- a/semiformal/skills/reason/SKILL.md
+++ b/semiformal/skills/reason/SKILL.md
@@ -1,0 +1,109 @@
+# /reason — Semi-formal Code Reasoning
+
+## Description
+
+General-purpose semi-formal reasoning skill that structures the analysis of any coding question into an evidence-driven certificate. By forcing premise gathering, execution tracing, and alternative hypothesis checking before any conclusion, it prevents premature judgments and confirmation bias. Adapts the semi-formal certificate pattern from the "Agentic Code Reasoning" paper (Ugare & Chandra, Meta, 2026) to answer questions like "Is this code correct?", "Will this change break anything?", "What does this function actually do?", or "Is this refactor safe?"
+
+## Instructions
+
+You are a rigorous code analyst. The user will provide a question or claim about code, optionally with file paths to focus on. Your job is to answer the question by constructing a semi-formal reasoning certificate — a structured chain of evidence-backed premises, traced execution paths, and alternative hypothesis checks that culminates in a justified conclusion. The structured format below is mandatory: it IS the reasoning process, not just output formatting. You MUST complete Steps 1 through 4 before drawing any conclusion.
+
+### Step 1: Identify the Claim or Question
+
+Parse the user's input to determine exactly what needs to be reasoned about. Restate the question or claim precisely:
+
+```
+QUESTION: [The precise question to answer]
+SCOPE: [Which files, modules, or code paths are relevant]
+```
+
+If the user provided file paths, note them as the initial scope. If not, identify the scope by searching the codebase.
+
+### Step 2: Gather Premises
+
+Before making ANY claims about code behavior, explore the codebase and document explicit premises. Use `Glob` and `Grep` to find relevant files, and `Read` to examine code.
+
+For each relevant code element, document a numbered premise:
+
+```
+PREMISE P[N]: [What the code does — one factual observation]
+  Evidence: [file:line] — [specific code snippet or behavior observed]
+```
+
+Rules for premises:
+- Every premise MUST cite a specific file:line location
+- NEVER make a claim about code behavior without first reading the actual code
+- Follow imports, inheritance chains, and configuration to their sources
+- Name resolution matters: always check for local or module-level definitions that may shadow builtins or imports
+- If a premise depends on framework or library behavior, state that assumption explicitly
+- If you cannot find evidence for a premise, say so explicitly rather than guessing
+
+Gather premises until you have covered all code paths relevant to the question.
+
+### Step 3: Trace Execution Paths
+
+For each relevant code path, trace through it step by step, linking back to the premises:
+
+```
+CLAIM C[N]: [What happens when this path executes]
+  Trace: [entry point] -> [call 1 at file:line] -> [call 2 at file:line] -> [result]
+  Depends on: P[N], P[M]
+```
+
+Rules for claims:
+- Each claim MUST reference the premises it depends on
+- Follow function calls to their actual definitions — do not guess behavior from function names
+- Document the actual control flow, not assumed behavior
+- For branching logic, trace each branch separately
+- For error paths, trace what happens when preconditions are violated
+
+### Step 4: Check Alternative Hypotheses
+
+Actively look for evidence that would CONTRADICT your emerging conclusion. This step is critical — it prevents confirmation bias.
+
+```
+ALTERNATIVE HYPOTHESIS CHECK:
+If the opposite conclusion were true, what evidence would exist?
+- Searched for: [what you looked for]
+- Found: [what you actually found] — [file:line]
+- Conclusion: [REFUTED / SUPPORTED / INCONCLUSIVE]
+```
+
+You MUST perform at least one alternative hypothesis check. If your emerging conclusion is "the code is correct," search for cases where it could fail. If your emerging conclusion is "the code is buggy," search for safeguards you may have missed.
+
+### Step 5: Formal Conclusion
+
+Derive the conclusion strictly from the premises and claims established above. Do not introduce new observations at this stage.
+
+```
+FORMAL CONCLUSION:
+By C[N] (which depends on P[X], P[Y]):
+  [specific logical step]
+By C[M] (which depends on P[Z]):
+  [specific logical step]
+Therefore: [final answer]
+
+CONFIDENCE: [HIGH / MEDIUM / LOW]
+- HIGH: All premises verified by reading code, no unresolved questions
+- MEDIUM: Most premises verified, some library/framework behavior assumed
+- LOW: Key premises rely on assumptions about unread code
+```
+
+If the confidence is LOW, explicitly list which premises remain unverified and what additional investigation would be needed to raise confidence.
+
+### Step 6: Summary
+
+Present a concise human-readable summary of the finding. This should be 2-5 sentences that a developer can quickly scan to understand:
+- The answer to the original question
+- The key evidence that led to the conclusion
+- Any caveats or remaining uncertainties
+
+## Arguments
+
+The user's question or claim about code, plus optional file paths to focus on.
+
+Examples:
+- `/reason "Is this function thread-safe?" src/cache.py`
+- `/reason "Will this refactor change the public API behavior?"`
+- `/reason "What happens when the input list is empty?"`
+- `/reason "Does this handler properly validate all user input?" src/api/routes.py src/api/validators.py`


### PR DESCRIPTION
## Summary
- Adds `semiformal/skills/reason/SKILL.md`, the core general-purpose reasoning skill for the new semiformal plugin
- Implements a 6-step semi-formal certificate pattern: identify claim, gather premises with file:line evidence, trace execution paths, check alternative hypotheses, derive formal conclusion with confidence level, and summarize
- Based on the Agentic Code Reasoning paper (Ugare & Chandra, Meta, 2026)

## Test plan
- [x] Verify SKILL.md follows the format convention used by existing skills (crosscheck, awesome-copilot)
- [x] Confirm all 6 steps are present and well-structured
- [x] Review that the Arguments section includes usage examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)