### PR TITLE
feat: add /analyze-code skill for semiformal plugin

### DIFF
--- a/semiformal/skills/analyze-code/SKILL.md
+++ b/semiformal/skills/analyze-code/SKILL.md
@@ -1,0 +1,109 @@
+# /analyze-code — Code Question Answering
+
+## Description
+
+Deep semantic analysis of code behavior using semi-formal reasoning. Forces systematic evidence gathering before answering questions about what code does, how it works, or whether specific properties hold.
+
+## Instructions
+
+You are a code analysis expert using semi-formal reasoning. The user will ask a question about code behavior. You must answer using the structured certificate format below — this is not optional formatting, it IS the analysis process.
+
+### Step 1: Understand the Question
+
+Parse the user's question and identify:
+- What specific code behavior is being asked about
+- What files/functions are relevant
+- What the expected answer might be (to test against)
+
+### Step 2: Build the Function Trace Table
+
+For every function/method relevant to the question, read its actual implementation and document:
+
+```
+FUNCTION TRACE TABLE:
+| Function/Method | File:Line | Parameter Types | Return Type | Behavior (VERIFIED) |
+|-----------------|-----------|-----------------|-------------|---------------------|
+| [function1]     | [file:N]  | [param types]   | [ret type]  | [ACTUAL behavior]   |
+| [function2]     | [file:N]  | [param types]   | [ret type]  | [ACTUAL behavior]   |
+```
+
+Rules:
+- The "Behavior (VERIFIED)" column must describe what the code ACTUALLY does, verified by reading it
+- Do NOT guess behavior from function names — read the implementation
+- If the function calls other functions, trace those too
+- If source is unavailable (third-party library), note it explicitly: "UNVERIFIED — library code"
+
+### Step 3: Perform Data Flow Analysis
+
+For each key variable relevant to the question:
+
+```
+DATA FLOW ANALYSIS:
+Variable: [key variable name]
+- Created at: [file:line] ([how it's initialized])
+- Modified at: [file:line(s)], or 'NEVER MODIFIED'
+- Used at: [file:line(s)]
+
+Variable: [another variable]
+- Created at: [file:line]
+- Modified at: [file:line(s)]
+- Used at: [file:line(s)]
+```
+
+This traces the lifecycle of data through the code, revealing mutations and dependencies.
+
+### Step 4: Identify Semantic Properties
+
+Based on the trace table and data flow, identify semantic properties with explicit evidence:
+
+```
+SEMANTIC PROPERTIES:
+Property 1: [e.g., 'The map is immutable after initialization']
+- Evidence: [file:line] — [what the code shows]
+- Evidence: [file:line] — [additional supporting evidence]
+
+Property 2: [e.g., 'All enum values are handled exhaustively']
+- Evidence: [file:line] — [specific code]
+```
+
+### Step 5: Alternative Hypothesis Check
+
+Before committing to an answer, check if the opposite answer could be true:
+
+```
+ALTERNATIVE HYPOTHESIS CHECK:
+If the opposite answer were true, what evidence would exist?
+- Searched for: [what you looked for]
+- Found: [what you found] — cite [file:line]
+- Conclusion: [REFUTED / SUPPORTED]
+```
+
+This prevents confirmation bias — a common failure mode in standard reasoning.
+
+### Step 6: Final Answer
+
+```
+<answer>[Final answer with explicit evidence citations]</answer>
+
+CONFIDENCE: [HIGH/MEDIUM/LOW]
+- HIGH: All functions traced, all data flows verified, alternative hypothesis refuted
+- MEDIUM: Most code traced, some library behavior assumed
+- LOW: Key code paths unverified or source unavailable
+```
+
+### Key Principles
+
+- The structured template forces evidence gathering BEFORE conclusion
+- Function names are unreliable — always read actual implementations
+- Name shadowing is a real risk — check for local/module-level definitions
+- Data flow analysis reveals mutations that inspection of a single function misses
+- The alternative hypothesis check is mandatory, not optional
+
+## Arguments
+
+The user's question about code, plus optional file paths.
+
+Examples:
+- `/analyze-code "Is there a difference between using .at() vs bracket notation here?" src/utils.ts`
+- `/analyze-code "Do we need this null check?" src/parser.py:45`
+- `/analyze-code "What happens when the cache expires during a request?"`


### PR DESCRIPTION
## Summary
- Adds the `/analyze-code` skill to the new `semiformal` plugin
- Implements the Code QA semi-formal template from the Agentic Code Reasoning paper (Ugare & Chandra, Meta, 2026)
- Forces structured evidence gathering (function trace tables, data flow analysis, semantic properties, alternative hypothesis checks) before answering questions about code behavior

## Test plan
- [x] Verify SKILL.md follows the established convention (matches crosscheck skill structure)
- [x] Confirm all six steps from the paper's template are included
- [x] No executable code — markdown-only skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)