### PR TITLE
docs: add semiformal plugin README and CLAUDE.md entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ Crosscheck plugin. Crosschecks Claude's code claims using Dafny as a verificatio
 - **Skills** (`crosscheck/skills/`): `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`
 - **Orchestrator agent** (`crosscheck/agents/verify-orchestrator.md`): End-to-end workflow automation
 
+### semiformal (`semiformal/`)
+
+Semi-formal reasoning plugin. Structures Claude's code analysis with explicit premises, execution traces, and formal conclusions.
+
+- **Skills** (`semiformal/skills/`): `/reason`, `/analyze-code`, `/compare-patches`, `/locate-fault`, `/trace-execution`
+- **Orchestrator agent** (`semiformal/agents/reasoning-orchestrator.md`): Automatic task classification and skill routing
+
 ### awesome-copilot (`awesome-copilot/`)
 
 Meta prompts for discovering and installing curated GitHub Copilot customizations.

--- a/semiformal/README.md
+++ b/semiformal/README.md
@@ -1,0 +1,43 @@
+# semiformal — Semi-formal Reasoning for Claude Code
+
+A Claude Code plugin that implements semi-formal reasoning from the "Agentic Code Reasoning" paper (Ugare & Chandra, Meta, 2026). Semi-formal reasoning is a structured prompting methodology that requires constructing explicit premises, tracing execution paths, and deriving formal conclusions. Unlike unstructured chain-of-thought, semi-formal reasoning acts as a certificate: the agent cannot skip cases or make unsupported claims.
+
+## Key Results from the Paper
+
+- **Patch equivalence**: 78% to 88% accuracy (curated), 93% on real-world patches
+- **Code question answering**: 87% accuracy on RubberDuckBench (+9pp over standard)
+- **Fault localization**: +5-12pp over standard reasoning
+
+## Usage
+
+### Skills
+
+Five independent skills for granular control:
+
+| Skill | Description |
+|-------|-------------|
+| `/reason` | General-purpose semi-formal reasoning for any code question |
+| `/analyze-code` | Deep code question answering with function trace tables and data flow analysis |
+| `/compare-patches` | Patch equivalence verification with structured proof/counterexample |
+| `/locate-fault` | Fault localization using 4-phase PREMISE -> CLAIM -> PREDICTION chain |
+| `/trace-execution` | Hypothesis-driven execution path tracing |
+
+### Orchestrator Agent
+
+For end-to-end workflows, use the `reasoning-orchestrator` agent which automatically classifies your problem and routes to the appropriate skill.
+
+## Core Principles
+
+1. Every claim must cite file:line evidence
+2. Always read actual code — never guess from function names
+3. Check alternative hypotheses before concluding
+4. The structured format IS the reasoning process, not just output formatting
+5. Name resolution matters — check for shadowing at every scope
+
+## When to Use
+
+- **Code review**: "Is this refactor safe?"
+- **Bug hunting**: "Why does this test fail?"
+- **Understanding code**: "What does this function actually do?"
+- **Comparing implementations**: "Are these two approaches equivalent?"
+- **Verifying claims**: "Is this code thread-safe?"


### PR DESCRIPTION
## Summary
- Created `semiformal/README.md` covering the plugin overview, paper results, skills table, orchestrator agent, core principles, and usage scenarios
- Updated root `CLAUDE.md` to list the semiformal plugin under the Plugins section, following the existing entry pattern

## Test plan
- [x] README content matches specification
- [x] CLAUDE.md entry follows existing plugin listing pattern
- [x] No code changes — documentation only

Generated with [Claude Code](https://claude.com/claude-code)