### PR TITLE
fix(release): remove bootstrap-sha now that crosscheck-v1.0.0 tag exists

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "bootstrap-sha": "1c18bf08b2c7a89dc54cbc496258be40b57a300d",
   "packages": {
     "crosscheck": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- Created tag `crosscheck-v1.0.0` + GitHub Release on current main as the baseline for release-please
- Removed `bootstrap-sha` from `release-please-config.json` — no longer needed since the tag is the authoritative anchor

## Root cause
`bootstrap-sha` was set to the HEAD of main at the time of the previous PR. After that PR merged (as `2afc604`), only 1 new commit existed — and it didn't touch any files under `crosscheck/`. So release-please correctly found 0 path-scoped commits and skipped.

The actual fix: release-please needs a **tag** matching `crosscheck-v1.0.0` to anchor its version history. With the tag + GitHub Release created, future `feat:` or `fix:` commits touching `crosscheck/` will trigger release PRs automatically.

## Verification
```
npx release-please release-pr --dry-run ...
# ✔ Found release for path crosscheck, crosscheck-v1.0.0
# ✔ release for path: crosscheck, version: 1.0.0, sha: 2afc604...
```