### PR TITLE
fix(crosscheck): correct release-please extra-files paths and add package.json

### DIFF
--- a/crosscheck/package.json
+++ b/crosscheck/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "crosscheck",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Crosscheck Claude code claims with Dafny formal verification"
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,12 +7,12 @@
       "extra-files": [
         {
           "type": "json",
-          "path": "crosscheck/.claude-plugin/plugin.json",
+          "path": ".claude-plugin/plugin.json",
           "jsonpath": "$.version"
         },
         {
           "type": "json",
-          "path": "crosscheck/mcp-server/package.json",
+          "path": "mcp-server/package.json",
           "jsonpath": "$.version"
         }
       ]


### PR DESCRIPTION
## What was wrong

Release-please was finding the `crosscheck-v1.0.0` tag correctly but reporting **0 commits** for the `crosscheck` path. Two root causes:

### 1. `extra-files` paths were repo-root-relative (wrong)

In PR #27, I changed the paths to include the `crosscheck/` prefix:
```json
"path": "crosscheck/.claude-plugin/plugin.json"
"path": "crosscheck/mcp-server/package.json"
```

But release-please's `addPath()` ([source](https://github.com/googleapis/release-please/blob/main/src/strategies/base.ts#L754-L770)) **automatically prepends the package path**, so these resolved to `crosscheck/crosscheck/...` which doesn't exist. The original paths (`.claude-plugin/plugin.json`, `mcp-server/package.json`) were correct — they're package-relative.

Evidence from real monorepos:
- **grain-lang/grain**: package `cli` uses `"path": "package.json"` (not `cli/package.json`)
- **taikoxyz/taiko-mono**: package `packages/ejector` uses `"path": "Cargo.toml"` (not `packages/ejector/Cargo.toml`)
- **puppeteer/puppeteer**: package `packages/puppeteer-core` uses `"path": "src/util/version.ts"`

### 2. No commits touched `crosscheck/` files since the tag

Release-please uses `CommitSplit` ([source](https://github.com/googleapis/release-please/blob/main/src/util/commit-split.ts#L99)) to filter commits by path — only commits where at least one file starts with `crosscheck/` are considered. All previous fix PRs (#27, #28) only touched root config files.

## What this PR does

1. **Reverts `extra-files` paths** to package-relative (the originals were correct)
2. **Adds `crosscheck/package.json`** — the `node` release-type expects a `package.json` at the package root for version bumping. This file also ensures the squash-merge commit touches `crosscheck/` files, giving release-please a path-scoped commit to work with.

## After merge

When this PR is squash-merged with its conventional title (`fix(crosscheck): ...`), release-please will:
1. Find `crosscheck-v1.0.0` tag ✅ (already working)
2. Find 1 new commit touching `crosscheck/package.json` ✅
3. Parse it as `fix:` → patch bump → open release PR for **v1.0.1**