### PR TITLE
docs: update crosscheck README with expanded skills and Dafny limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ A collection of Claude Code plugins. Each plugin is a self-contained directory w
 
 ### [crosscheck](./crosscheck/)
 
-Crosscheck Claude's code claims with [Dafny](https://dafny.org/) formal verification. The LLM proposes Dafny specs and implementations, the Dafny verifier acts as a hard correctness gate, and only verified code gets extracted to the target language. No Dafny artifacts are committed — only clean Python/Go output.
+Crosschecks Claude's code claims using [Dafny](https://dafny.org/) formal verification for provably correct Python/Go code, plus semi-formal reasoning for structured code analysis.
 
 | | |
 |---|---|
-| **Skills** | `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify` |
-| **Agent** | `verify-orchestrator` — end-to-end workflow automation |
-| **MCP tools** | `dafny_verify`, `dafny_compile`, `dafny_cleanup` |
+| **MCP server** | `dafny_verify`, `dafny_compile`, `dafny_cleanup` |
+| **Docker isolation** | Dafny 4.11.0 in a sandboxed container (no network, 512 MB memory, 120 s timeout) |
+| **Formal verification skills** | `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify` |
+| **Spec management & adequacy skills** | `/check-regressions`, `/suggest-specs`, `/rationale` |
+| **Semi-formal reasoning skills** | `/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution` |
+| **Agent** | `byfuglien` — unified task classification, skill routing, and output validation |
 
 **Prerequisites:** Docker, Node.js >= 18
 
@@ -59,3 +62,10 @@ npm run test:e2e           # End-to-end tests (requires Docker)
 - Zod for runtime validation of tool inputs
 - vitest with fast-check for property-based testing
 - Docker image name configured via `DAFNY_DOCKER_IMAGE` env var (default: `crosscheck-dafny:latest`)
+
+### Dafny limitations to keep in mind
+
+- No IO/networking verification — requires `{:extern}` trust boundaries
+- No concurrency modeling — sequential correctness only
+- Go output uses type erasure to `interface{}` — may need type assertions
+- `real` type compiles to `_dafny.BigRational`, not native floats


### PR DESCRIPTION
## Summary
Updated the crosscheck plugin documentation to reflect the expanded capabilities of the system, including new semi-formal reasoning skills, improved agent architecture, and important Dafny limitations that users should be aware of.

## Key Changes
- **Clarified plugin description**: Simplified the overview to emphasize both formal verification and semi-formal reasoning capabilities
- **Reorganized feature table**: 
  - Renamed "MCP tools" to "MCP server" for clarity
  - Added Docker isolation details (Dafny 4.11.0 with resource constraints)
  - Expanded skills into three categories: formal verification, spec management & adequacy, and semi-formal reasoning
  - Updated agent name from `verify-orchestrator` to `byfuglien` with description of its responsibilities
- **Added Dafny limitations section**: New documentation covering important constraints:
  - IO/networking verification limitations
  - Sequential-only correctness (no concurrency)
  - Go type erasure behavior
  - Real number type compilation details

## Notable Details
The changes reflect a more mature understanding of the system's capabilities and constraints, providing users with clearer expectations about what the tool can and cannot verify, and how to work within Dafny's limitations.

https://claude.ai/code/session_0172su3RXChd5SaH8MyfGXpH