### PR TITLE
Add TypeScript analyzer and expand documentation

### DIFF
--- a/logic-distribution/README.md
+++ b/logic-distribution/README.md
@@ -1,8 +1,15 @@
 # Codebase Logic Distribution Analyzer
 
-Static analysis tool that classifies every function/method in a Django codebase by where its logic lives. Answers the question: **"what percentage of a real codebase is reachable by formal verification tools like Dafny or Lean?"**
+Static analysis tools that classify every function/method in a codebase by where its logic lives. Answers the question: **"what percentage of a real codebase is reachable by formal verification tools like Dafny or Lean?"**
+
+Two analyzers are included:
+
+- **Python analyzer** (`logic_distribution.py`) — targets Django, Flask, FastAPI, and other Python frameworks
+- **TypeScript analyzer** (`ts/logic_distribution.ts`) — targets React, Next.js, Express, NestJS, Vue, Angular, and other JS/TS frameworks
 
 ## Quick Start
+
+### Python
 
 ```bash
 # Analyze a Django project
@@ -27,7 +34,31 @@ python logic_distribution.py /path/to/project --output results.json
 python logic_distribution.py /path/to/project --no-json
 ```
 
+### TypeScript
+
+```bash
+cd ts && npm install
+
+# Analyze a JS/TS project
+npx tsx logic_distribution.ts /path/to/react
+
+# Verbose output
+npx tsx logic_distribution.ts /path/to/nextjs-app --verbose
+
+# Spot-check 20 random functions
+npx tsx logic_distribution.ts /path/to/express-api --spot-check 20
+
+# Summary only / custom output / skip JSON — same flags as the Python analyzer
+npx tsx logic_distribution.ts /path/to/project --summary-only
+npx tsx logic_distribution.ts /path/to/project --output results.json
+npx tsx logic_distribution.ts /path/to/project --no-json
+```
+
+Analyzes `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, and `.mts` files using the TypeScript compiler API. Automatically skips `node_modules`, `dist`, `build`, and other output directories.
+
 ## Classification Categories
+
+### Python analyzer
 
 | Category | Description |
 |---|---|
@@ -39,9 +70,23 @@ python logic_distribution.py /path/to/project --no-json
 | **TEST_CODE** | Functions in test files (excluded from main analysis) |
 | **CONFIGURATION** | Migrations, settings, app configs (excluded from main analysis) |
 
+### TypeScript analyzer
+
+| Category | Description |
+|---|---|
+| **DATABASE_ORM** | Prisma, TypeORM, Sequelize, Knex, Drizzle, Mongoose, MongoDB, Redis — ORM/database operations |
+| **SCHEMA_VALIDATION** | Zod, Yup, Joi, class-validator, io-ts, Valibot, Arktype — schema definitions and validation |
+| **VIEW_FRAMEWORK** | React components, JSX, hooks, Express/Fastify route handlers, NestJS controllers, GraphQL resolvers, Redux, tRPC — framework-orchestrated UI and request handling |
+| **PURE_FUNCTION** | No framework imports, no ORM, no IO, no side effects — **formally verifiable** |
+| **EXTERNAL_IO** | fs, child_process, net, http/https, axios, fetch, WebSocket, AWS SDK — IO operations |
+| **TEST_CODE** | Files matching `.test.*`, `.spec.*`, `__tests__/`, `__mocks__/`, `.stories.tsx` (excluded from main analysis) |
+| **CONFIGURATION** | webpack/vite/rollup configs, migrations, seeds, `.env` files (excluded from main analysis) |
+
 ### Priority Rules
 
 When a function touches multiple categories, the highest-priority match wins:
+
+**Python:**
 
 1. Test file → TEST_CODE
 2. Migration/settings file → CONFIGURATION
@@ -49,6 +94,16 @@ When a function touches multiple categories, the highest-priority match wins:
 4. Contains external IO → EXTERNAL_IO
 5. Framework class method or uses Django-imported names → VIEW_MIDDLEWARE
 6. Model/manager method without ORM → MODEL_VALIDATION
+7. None of the above → PURE_FUNCTION
+
+**TypeScript:**
+
+1. Test file → TEST_CODE
+2. Config file → CONFIGURATION
+3. Contains ORM/database operations → DATABASE_ORM
+4. Contains external IO → EXTERNAL_IO
+5. Framework component/handler/hook → VIEW_FRAMEWORK
+6. Contains schema validation → SCHEMA_VALIDATION
 7. None of the above → PURE_FUNCTION
 
 ## Output
@@ -130,6 +185,29 @@ Excluded: 13800 test functions, 494 configuration functions
 | **Netflix Dispatch** | FastAPI + SQLAlchemy | 3,010 | 2,448 | 562 | 0 |
 | **Home Assistant** | Custom (HA Core) | 85,942 | 41,100 | 44,842 | 0 |
 
+### Comparative Results (6 codebases) — TypeScript
+
+#### By lines of code (%)
+
+| Category | React | VSCode | Strapi | Cal.com | Excalidraw | Payload |
+|---|---|---|---|---|---|---|
+| DATABASE_ORM | 5.0% | 7.4% | 15.3% | 23.3% | 5.0% | 23.5% |
+| SCHEMA_VALIDATION | 0.1% | 0.0% | 1.1% | 1.5% | 0.0% | 0.4% |
+| VIEW_FRAMEWORK | 26.7% | 1.3% | 43.8% | 45.1% | 27.1% | 30.1% |
+| PURE_FUNCTION | 65.6% | **89.9%** | 36.1% | 27.1% | **65.0%** | 40.0% |
+| EXTERNAL_IO | 2.5% | 1.4% | 3.7% | 3.0% | 2.9% | 5.9% |
+
+#### Raw numbers
+
+| Project | Stack | Total funcs | Main funcs | Excl. tests | Excl. config |
+|---|---|---|---|---|---|
+| **React** | React (framework) | 11,466 | 8,223 | 2,637 | 606 |
+| **VSCode** | Electron + TypeScript | 59,128 | 54,962 | 4,144 | 22 |
+| **Strapi** | Node + Koa | 5,450 | 4,758 | 590 | 102 |
+| **Cal.com** | Next.js + Prisma | 12,699 | 11,881 | 767 | 51 |
+| **Excalidraw** | React + Canvas | 2,389 | 2,225 | 164 | 0 |
+| **Payload** | Next.js + MongoDB | 5,611 | 4,630 | 903 | 78 |
+
 ### Key Findings
 
 1. **DATABASE_ORM tracks the hypothesis in Django apps** — Saleor (35%), Zulip (37%), and NetBox (41%) confirm the ~40% prediction by lines. Non-Django apps show lower ORM percentages because SQLAlchemy patterns are more spread across service layers.
@@ -147,21 +225,40 @@ Excluded: 13800 test functions, 494 configuration functions
 
 6. **Framework architecture determines VIEW_MIDDLEWARE vs PURE split** — the combined VIEW_MIDDLEWARE + PURE_FUNCTION is ~60-70% across all projects. What varies is the ratio between them: framework-heavy apps (HA, Django itself) skew toward VIEW_MIDDLEWARE; data-processing apps (Redash) skew toward PURE.
 
+7. **TypeScript codebases skew even higher on PURE_FUNCTION** — VSCode at 90% and React at 66% dwarf the Python numbers. Pure computation dominates in codebases that aren't directly wired to databases or HTTP frameworks.
+
+8. **Full-stack TS apps mirror Django apps** — Cal.com (27% pure, 45% view/framework) and Strapi (36% pure, 44% view/framework) look structurally similar to Saleor and Dispatch. The framework + pure split is consistent regardless of language.
+
+9. **SCHEMA_VALIDATION is negligible everywhere** — despite Zod/Yup's popularity, schema code is consistently <2% of lines. Validation logic is small even when it's pervasive.
+
 ### Implications for Formal Verification
 
-Across 8 codebases spanning 4 frameworks and ~1M lines of analyzed code:
+Across 14 codebases spanning 8+ frameworks and ~1.5M lines of analyzed code:
 
 - **~20-30% of a typical Python web application is formally verifiable** by tools like Dafny — 2-3x the hypothesized 10%
+- **TypeScript codebases range from 27% to 90% pure** — desktop/library code (VSCode, React) is overwhelmingly pure; full-stack apps (Cal.com, Strapi) are comparable to Python web apps
 - The exception is IoT/hardware-integration code (Home Assistant: 11%) where almost everything interacts with external state
-- Data-processing applications (Redash: 46%) have the highest verification potential
-- The highest-value targets remain in the **non-pure 70-80%** — ORM query correctness, state machine transitions, authorization logic — where bugs are most impactful but current tools can't reach
+- Data-processing and library applications (Redash: 46%, Excalidraw: 65%, VSCode: 90%) have the highest verification potential
+- The highest-value targets remain in the **non-pure code** — ORM query correctness, state machine transitions, authorization logic — where bugs are most impactful but current tools can't reach
 
 ## Known Limitations
 
-1. **Indirect ORM access**: Functions that call other functions which in turn call ORM are not detected. Only direct ORM usage in the function body is analyzed.
-2. **Dynamic dispatch**: Python's dynamic nature means some calls can't be resolved statically (e.g., `getattr`, `**kwargs` forwarding).
-3. **Class hierarchy**: Only direct base classes are checked, not the full MRO. A class inheriting from a custom `BaseView` that itself inherits from `View` won't be detected unless `BaseView` is in the detection set.
-4. **GraphQL detection**: Relies on common Graphene/Strawberry patterns. Custom GraphQL frameworks may not be detected.
-5. **Pure function false positives**: Functions classified as pure by absence may actually have side effects through indirect calls, dynamic attribute access, or closures over mutable state.
-6. **Single-file scope**: Each function is classified independently. Cross-function data flow is not analyzed.
+### Shared
+
+1. **Indirect calls**: Functions calling other functions that in turn perform ORM/IO are not detected. Only direct usage in the function body is analyzed.
+2. **Single-file scope**: Each function is classified independently. Cross-function data flow is not analyzed.
+3. **Pure function false positives**: Functions classified as pure by absence may have side effects through indirect calls, dynamic attribute access, or closures over mutable state.
+
+### Python-specific
+
+4. **Dynamic dispatch**: Python's dynamic nature means some calls can't be resolved statically (e.g., `getattr`, `**kwargs` forwarding).
+5. **Class hierarchy**: Only direct base classes are checked, not the full MRO. A class inheriting from a custom `BaseView` that itself inherits from `View` won't be detected unless `BaseView` is in the detection set.
+6. **GraphQL detection**: Relies on common Graphene/Strawberry patterns. Custom GraphQL frameworks may not be detected.
 7. **No type inference**: The analysis doesn't use type information to determine if a variable is a QuerySet, Model instance, etc.
+
+### TypeScript-specific
+
+8. **No type-level analysis**: The analyzer uses AST pattern matching, not the TypeScript type checker. It cannot determine if a variable is a `PrismaClient` instance via type flow.
+9. **Re-exports and barrel files**: Imports that pass through barrel files (`index.ts`) may not be recognized as framework imports if the original module name is lost.
+10. **Dynamic imports**: `import()` expressions and `require()` with variable paths are not traced.
+11. **Decorator detection**: Limited to NestJS and class-validator patterns. Custom decorators from other frameworks may not trigger classification.


### PR DESCRIPTION
## Summary

This PR expands the logic distribution analyzer to support TypeScript/JavaScript codebases in addition to Python. The README has been updated to document both analyzers, their classification categories, priority rules, and comparative results across 14 codebases.

## Key Changes

- **Documentation restructure**: Reorganized README to clearly distinguish between Python and TypeScript analyzers
  - Added separate "Quick Start" sections for each language with usage examples
  - Documented TypeScript analyzer features (file type support, automatic directory skipping)
  
- **Classification categories**: Added TypeScript-specific categories
  - DATABASE_ORM: Prisma, TypeORM, Sequelize, Knex, Drizzle, Mongoose, MongoDB, Redis
  - SCHEMA_VALIDATION: Zod, Yup, Joi, class-validator, io-ts, Valibot, Arktype
  - VIEW_FRAMEWORK: React components, hooks, Express/Fastify handlers, NestJS controllers, GraphQL resolvers, Redux, tRPC
  - PURE_FUNCTION, EXTERNAL_IO, TEST_CODE, CONFIGURATION (same as Python)

- **Priority rules**: Added separate priority rule chains for Python and TypeScript to reflect language-specific detection patterns

- **Comparative results**: Added new section with TypeScript analysis results
  - 6 codebases: React, VSCode, Strapi, Cal.com, Excalidraw, Payload
  - Breakdown by lines of code and raw function counts
  - Key finding: TypeScript codebases show 27-90% pure functions, with desktop/library code (VSCode 90%, React 66%) significantly higher than full-stack apps

- **Key findings**: Expanded implications section
  - Added observations about TypeScript codebases ranging from 27% to 90% pure
  - Noted structural similarity between full-stack TS apps (Cal.com, Strapi) and Python web apps
  - Highlighted that SCHEMA_VALIDATION is negligible across all languages (<2%)

- **Known limitations**: Reorganized and expanded
  - Separated shared limitations from language-specific ones
  - Added TypeScript-specific limitations: no type-level analysis, re-exports/barrel files, dynamic imports, decorator detection

## Notable Details

- Updated scope claim from "8 codebases, ~1M lines" to "14 codebases, ~1.5M lines"
- Maintained consistent formatting and structure between Python and TypeScript documentation
- All changes are documentation-only; no source code modifications to analyzers themselves

https://claude.ai/code/session_01F6dthYJk3u776Bho5jrJkc