### PR TITLE
feat(crosscheck): add /invariant-coverage-scaffold skill

### DIFF
--- a/crosscheck/skills/invariant-coverage-scaffold/SKILL.md
+++ b/crosscheck/skills/invariant-coverage-scaffold/SKILL.md
@@ -2,7 +2,7 @@
 name: invariant-coverage-scaffold
 description: >-
   Generate a bidirectional invariant-to-test coverage gate for a repo that uses
-  docs/invariants/*.md plus `// Invariant IN: <ID>` test comments. Emits both a
+  docs/invariants/*.md plus `// Invariant <ID>: <Name>` test comments. Emits both a
   pre-commit hook and a CI job (dual-track enforcement), adapted to the target
   repo's language and test framework. v1 supports Go, Python, TypeScript;
   Rust/Ruby/Java are deferred to later versions. Triggers: "invariant coverage",
@@ -14,7 +14,7 @@ argument-hint: "[optional: language override — go | python | typescript]"
 
 ## Description
 
-Scaffold the mechanical gate that enforces the bidirectional link between invariant IDs declared in `docs/invariants/*.md` and `// Invariant IN: <ID>` comments in property-test files. The gate catches two failure modes:
+Scaffold the mechanical gate that enforces the bidirectional link between invariant IDs declared in `docs/invariants/*.md` and `// Invariant <ID>: <Name>` comments in property-test files (e.g. `// Invariant I1: QueueEnqueueDequeue`). The gate catches two failure modes:
 
 1. **Silent test drop.** An invariant exists in the doc but no test references it → coverage is claimed that does not exist.
 2. **Orphan test comment.** A test references an invariant ID that is not declared in any module doc → stale or typo'd reference.
@@ -27,6 +27,14 @@ This skill generates both enforcement points required by the dual-track enforcem
 The skill is a generator, not a runtime. It emits scripts and config files adapted to the target repo's language and tooling, then wires them into the existing hook framework and CI system.
 
 **Language coverage (v1):** Go, Python, TypeScript. **Deferred to later versions:** Rust, Ruby, Java. If the target repo is one of the deferred languages, emit a clear notice and stop — do not fabricate a template.
+
+**Boundary vs `/assurance-init`:** `/assurance-init` scaffolds the governance skeleton (ROADMAP, horizon dirs, `docs/invariants/` with seed module docs, `.claude/rules/protected-surfaces.md`). This skill installs the mechanical coverage gate on top. Expected ordering:
+
+1. `/assurance-init` (or the equivalent manual setup) — creates `docs/invariants/*.md` with `**I1. Name.**` headers.
+2. `/draft-invariants` for each seeded module — populates real invariant prose.
+3. `/invariant-coverage-scaffold` (this skill) — wires the enforcement gate.
+
+If `docs/invariants/` is missing when this skill runs, stop and recommend `/assurance-init` before proceeding. Do not create `docs/invariants/` as a side effect — that is `/assurance-init`'s responsibility.
 
 ## Instructions
 
@@ -127,6 +135,8 @@ Each template contains:
 - The CI workflow snippet for GitHub Actions and GitLab CI.
 - The actionable error message (including the exact fix command) the script prints on failure.
 
+If a coverage script already exists at the target path, **do not overwrite**. Diff the existing content against the template, show the user the differences, and ask before replacing. On a clean re-run with no drift, skip the write and report "script already up to date".
+
 Fill the placeholders using the choices from Steps 1–4. Write the script to the standard location:
 
 - Go → `scripts/check_invariant_coverage.go` (as a `//go:build ignore` tool) or `cli/cmd/check-invariants/main.go` if a `cli/` tree already exists.
@@ -153,6 +163,8 @@ Add a CI job or step that calls the same script. Use the CI snippet from the tem
 - **GitHub Actions** — if `.github/workflows/ci.yml` or similar exists, add a step. If none exist, create `.github/workflows/invariant-coverage.yml` as a minimal standalone workflow.
 - **GitLab CI** — add a job to `.gitlab-ci.yml`.
 - **Generic** — emit `ci/invariant-coverage.sh` with a clear "Call this from your CI pipeline" comment.
+
+Before adding a step or job, **grep the target file for an existing `invariant-coverage` entry**. If one is already present, skip the write and report "CI step already wired". Never append a duplicate step on a re-run.
 
 The CI step must fail the build (`exit 1`) when the script fails. Do not downgrade to warning-only — that defeats dual-track enforcement.
 
@@ -184,7 +196,7 @@ Verification:
 Next steps:
   - Commit the new files.
   - Run /draft-invariants on any module that has no invariant doc yet.
-  - Add `// Invariant IN: <ID>` comments to property tests that lack them.
+  - Add `// Invariant <ID>: <Name>` comments to property tests that lack them.
 ```
 
 ### Verification Checklist
@@ -202,7 +214,7 @@ Run each item against the generated script before considering the gate live:
 - [ ] Script runs in under 10 seconds on a repo with ~200 invariants (measure with `time <command>`).
 - [ ] Pre-commit hook is wired and fires on changes to `docs/invariants/**/*.md` or property-test files.
 - [ ] CI job is wired and fails the build on coverage gaps (verify with a throwaway PR that removes a test comment).
-- [ ] Error messages include the exact fix command (e.g., `add \`// Invariant IN: <ID>\` to a test`).
+- [ ] Error messages include the exact fix command (e.g., `add \`// Invariant <ID>: <Name>\` to a test`).
 - [ ] Regex format is strict: `// Invariant <ID>: <Name>` is the only accepted comment form; `// Invariant: <ID>` and similar variations are rejected.
 - [ ] Invariant IDs contain a digit by construction (typos that drop the digit surface as missing-coverage on the original ID, not as orphans — documented behavior).
 ```

--- a/crosscheck/skills/invariant-coverage-scaffold/SKILL.md
+++ b/crosscheck/skills/invariant-coverage-scaffold/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: invariant-coverage-scaffold
+description: >-
+  Generate a bidirectional invariant-to-test coverage gate for a repo that uses
+  docs/invariants/*.md plus `// Invariant IN: <ID>` test comments. Emits both a
+  pre-commit hook and a CI job (dual-track enforcement), adapted to the target
+  repo's language and test framework. v1 supports Go, Python, TypeScript;
+  Rust/Ruby/Java are deferred to later versions. Triggers: "invariant coverage",
+  "coverage gate", "scaffold invariant check", "enforce invariant tests".
+argument-hint: "[optional: language override — go | python | typescript]"
+---
+
+# /invariant-coverage-scaffold — Invariant Coverage Gate Generator
+
+## Description
+
+Scaffold the mechanical gate that enforces the bidirectional link between invariant IDs declared in `docs/invariants/*.md` and `// Invariant IN: <ID>` comments in property-test files. The gate catches two failure modes:
+
+1. **Silent test drop.** An invariant exists in the doc but no test references it → coverage is claimed that does not exist.
+2. **Orphan test comment.** A test references an invariant ID that is not declared in any module doc → stale or typo'd reference.
+
+This skill generates both enforcement points required by the dual-track enforcement principle:
+
+- A **pre-commit hook** (< 5 s, fast, actionable error) that blocks the commit locally.
+- A **CI job** that runs on every PR regardless of how the change was authored.
+
+The skill is a generator, not a runtime. It emits scripts and config files adapted to the target repo's language and tooling, then wires them into the existing hook framework and CI system.
+
+**Language coverage (v1):** Go, Python, TypeScript. **Deferred to later versions:** Rust, Ruby, Java. If the target repo is one of the deferred languages, emit a clear notice and stop — do not fabricate a template.
+
+## Instructions
+
+You are generating a portable invariant-coverage gate. Your output is committed into the user's repo. Be conservative: detect before you write, show your choices before you emit files, and always emit both enforcement points.
+
+### Step 1: Detect Target Language
+
+Check for marker files in this priority order:
+
+1. `go.mod` at the repo root → **Go**
+2. `pyproject.toml` (or `setup.py`, `setup.cfg`) at the repo root → **Python**
+3. `package.json` at the repo root → **TypeScript** (if `tsconfig.json` also present) or JavaScript
+
+If **multiple markers** are found (e.g., a Go backend with a TypeScript frontend), list each candidate and ask the user which to prioritise. Do not silently pick one.
+
+If **none** of Go/Python/TypeScript markers are found, stop and emit:
+
+```
+Unsupported language for v1. Found: <detected markers or 'none'>.
+v1 supports Go, Python, TypeScript. Rust, Ruby, Java are deferred to later versions.
+If the target language has a similar doc-plus-test layout, a follow-up skill version
+can add it — file a request citing this skill.
+```
+
+If the user passes an explicit language argument (`go`, `python`, `typescript`), respect it and skip detection.
+
+### Step 2: Detect Test Framework
+
+Given the chosen language, identify the property-test framework the repo already uses so the generated script looks for the right file glob.
+
+| Language | Primary framework | Secondary | Default test glob |
+|---|---|---|---|
+| Go | `testing` stdlib with `gopter` or `rapid` | plain `testing` | `**/*_invariants_prop_test.go`, fallback `**/*_test.go` |
+| Python | `pytest` + `hypothesis` | plain `unittest` | `tests/**/*.py`, fallback `**/*_test.py` |
+| TypeScript | `vitest` or `jest` + `fast-check` | plain `vitest`/`jest` | `**/*.test.ts`, `**/*.spec.ts` |
+
+Detect by grepping for the framework's import in existing tests. Report what you found: "Detected `github.com/leanovate/gopter` imports in 4 files — using gopter-style test glob."
+
+If no tests exist yet, pick the default glob and note: "No existing property tests found. Generated script uses the default glob `<glob>`; adjust in `scripts/check_invariant_coverage.<ext>` if your convention differs."
+
+### Step 3: Detect Pre-commit Framework
+
+Check, in order:
+
+1. `.pre-commit-config.yaml` → **pre-commit.com**
+2. `lefthook.yml` / `lefthook.yaml` → **lefthook**
+3. `package.json` with a `husky` devDependency or `.husky/` directory → **husky**
+4. None of the above → **standalone**
+
+For `standalone`, emit a warning and still generate a shell-executable `scripts/pre-commit-invariant-coverage.sh` that the user can wire up manually (e.g., via a `git config core.hooksPath` or direct `.git/hooks/pre-commit` entry). Document this in the final report.
+
+### Step 4: Detect CI System
+
+Check, in order:
+
+1. `.github/workflows/` → **GitHub Actions**
+2. `.gitlab-ci.yml` → **GitLab CI**
+3. Neither → **generic**
+
+For `generic`, emit a `ci/invariant-coverage.sh` shell stub the user can call from whatever CI they have, with a warning noting the CI integration is manual.
+
+### Step 5: Confirm Plan With User
+
+Before writing any files, print a summary and ask for confirmation:
+
+```
+Plan:
+  Language:          <go | python | typescript>
+  Test framework:    <detected framework>
+  Test glob:         <glob>
+  Pre-commit:        <pre-commit.com | lefthook | husky | standalone (warning)>
+  CI:                <github-actions | gitlab-ci | generic (warning)>
+  Files to create:
+    - scripts/check_invariant_coverage.<ext>
+    - <hook config snippet appended to <hook-config-file>>
+    - <ci workflow file or step>
+  Files to read-only inspect:
+    - docs/invariants/*.md
+    - <test files matching glob>
+Proceed? [y/N]
+```
+
+Wait for explicit confirmation. If the user declines, stop cleanly — do not write partial output.
+
+### Step 6: Emit Coverage Script
+
+Use the language-specific template under `references/`:
+
+- Go → `references/go-template.md`
+- Python → `references/python-template.md`
+- TypeScript → `references/typescript-template.md`
+
+Each template contains:
+
+- The script body (invariant-ID parser for `docs/invariants/**/*.md`; test-comment grep for the language's test glob).
+- Placeholders (marked `<placeholder>`) for repo-specific values: test glob, output path, allowed invariant-ID prefix regex.
+- The pre-commit config snippet for every supported hook framework.
+- The CI workflow snippet for GitHub Actions and GitLab CI.
+- The actionable error message (including the exact fix command) the script prints on failure.
+
+Fill the placeholders using the choices from Steps 1–4. Write the script to the standard location:
+
+- Go → `scripts/check_invariant_coverage.go` (as a `//go:build ignore` tool) or `cli/cmd/check-invariants/main.go` if a `cli/` tree already exists.
+- Python → `scripts/check_invariant_coverage.py` (executable, `#!/usr/bin/env python3`).
+- TypeScript → `scripts/check-invariant-coverage.ts` (runnable via `npx tsx` or `node --loader`).
+
+Make the script executable (`chmod +x` equivalent) if applicable for the language.
+
+### Step 7: Wire In The Pre-commit Hook
+
+Append the hook entry from the template to the detected hook config. Do **not** rewrite the file — append or insert, preserving existing hooks. For each framework:
+
+- **pre-commit.com** — add a `repos[].hooks[]` entry with `id: invariant-coverage`, `files` regex covering `docs/invariants/.*\\.md$` and the test glob.
+- **lefthook** — add a `pre-commit.commands.invariant-coverage` entry.
+- **husky** — add a line to `.husky/pre-commit` (creating the file if needed).
+- **standalone** — write `scripts/pre-commit-invariant-coverage.sh` and print the exact `git config core.hooksPath` command the user needs to run.
+
+The hook must run in **under 10 seconds on a repo with ~200 invariants** (see Verification Checklist). If the script is slower, optimise the parser before shipping.
+
+### Step 8: Wire In The CI Job
+
+Add a CI job or step that calls the same script. Use the CI snippet from the template.
+
+- **GitHub Actions** — if `.github/workflows/ci.yml` or similar exists, add a step. If none exist, create `.github/workflows/invariant-coverage.yml` as a minimal standalone workflow.
+- **GitLab CI** — add a job to `.gitlab-ci.yml`.
+- **Generic** — emit `ci/invariant-coverage.sh` with a clear "Call this from your CI pipeline" comment.
+
+The CI step must fail the build (`exit 1`) when the script fails. Do not downgrade to warning-only — that defeats dual-track enforcement.
+
+### Step 9: Declare The Opt-out Marker
+
+Aspirational invariants (declared but not yet test-covered) use the literal HTML comment `<!-- aspirational -->` on the same line as the invariant header. This marker is **skipped by the missing-coverage check**; the orphan-comment check still applies.
+
+The script must parse and respect this marker. The regex for detection (HTML comment, possibly preceded by whitespace) is included in every template.
+
+Document the marker convention by appending a short note to `docs/invariants/README.md` if one exists, or emitting a standalone `docs/invariants/COVERAGE.md` if it does not. Do **not** overwrite existing coverage prose — append only.
+
+### Step 10: Report
+
+Emit a concise report to the user:
+
+```
+Created:
+  - scripts/check_invariant_coverage.<ext>
+  - <hook-config-changes>
+  - <ci-workflow-changes>
+  - <doc-append-or-create>
+
+Verification:
+  Run the script locally:
+    $ <exact command>
+  Expected output on a healthy repo: "invariant coverage OK"
+  Expected output on a gap: "missing coverage for <ID>" or "orphan comment at <file:line>"
+
+Next steps:
+  - Commit the new files.
+  - Run /draft-invariants on any module that has no invariant doc yet.
+  - Add `// Invariant IN: <ID>` comments to property tests that lack them.
+```
+
+### Verification Checklist
+
+Present this checklist alongside the generated files so the user can confirm the gate is correctly wired:
+
+```
+## Verification Checklist
+
+Run each item against the generated script before considering the gate live:
+
+- [ ] Invariants declared in `docs/invariants/**/*.md` without a covering test → script exits non-zero and prints the missing ID.
+- [ ] Test comments referencing non-existent invariant IDs → script exits non-zero and prints the orphan file:line.
+- [ ] Invariants marked `<!-- aspirational -->` are skipped by the missing-coverage check but orphan-comment checks still apply.
+- [ ] Script runs in under 10 seconds on a repo with ~200 invariants (measure with `time <command>`).
+- [ ] Pre-commit hook is wired and fires on changes to `docs/invariants/**/*.md` or property-test files.
+- [ ] CI job is wired and fails the build on coverage gaps (verify with a throwaway PR that removes a test comment).
+- [ ] Error messages include the exact fix command (e.g., `add \`// Invariant IN: <ID>\` to a test`).
+- [ ] Regex format is strict: `// Invariant <ID>: <Name>` is the only accepted comment form; `// Invariant: <ID>` and similar variations are rejected.
+- [ ] Invariant IDs contain a digit by construction (typos that drop the digit surface as missing-coverage on the original ID, not as orphans — documented behavior).
+```
+
+## Arguments
+
+Optional language override. If omitted, the skill auto-detects.
+
+Examples:
+- `/invariant-coverage-scaffold` — auto-detect language and framework.
+- `/invariant-coverage-scaffold go` — force Go template.
+- `/invariant-coverage-scaffold python` — force Python template.
+- `/invariant-coverage-scaffold typescript` — force TypeScript template.
+
+## References
+
+- `references/go-template.md` — Go script, hook configs, CI snippets.
+- `references/python-template.md` — Python script, hook configs, CI snippets.
+- `references/typescript-template.md` — TypeScript script, hook configs, CI snippets.
+
+Each reference file contains the script template, the pre-commit hook config for every supported framework, the CI job snippet for GitHub Actions and GitLab CI, and the actionable error message printed on failure.

--- a/crosscheck/skills/invariant-coverage-scaffold/references/go-template.md
+++ b/crosscheck/skills/invariant-coverage-scaffold/references/go-template.md
@@ -1,0 +1,199 @@
+# Go Template — Invariant Coverage Gate
+
+Emit a Go tool that parses invariant IDs from `docs/invariants/**/*.md` and cross-checks them against `// Invariant <ID>: <Name>` comments in the repo's test files. Placeholders are marked `<placeholder>`.
+
+## Script Template
+
+Write to `scripts/check_invariant_coverage.go` (runnable via `go run`). For repos with a `cli/` tree, prefer `cli/cmd/check-invariants/main.go`.
+
+```go
+//go:build ignore
+
+// Bidirectional invariant-to-test coverage gate.
+// Run: go run scripts/check_invariant_coverage.go
+// Exits 0 on success, 1 on any coverage gap or orphan comment.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var (
+	headerRe       = regexp.MustCompile(`^\*\*([A-Z]+\d+[a-z]?)\.\s`)    // "**I1. Name.**"
+	commentRe      = regexp.MustCompile(`^//\s*Invariant\s+([A-Z]+\d+[a-z]?):\s`) // "// Invariant I1: Name."
+	aspirationalRe = regexp.MustCompile(`<!--\s*aspirational\s*-->`)
+
+	testSuffix = "<test-suffix>" // e.g. "_invariants_prop_test.go"
+	invDir     = "docs/invariants"
+)
+
+type entry struct {
+	module, id, path string
+	line             int
+	aspirational     bool
+}
+
+func scan(path string, re *regexp.Regexp) ([]entry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var out []entry
+	s := bufio.NewScanner(f)
+	for ln := 1; s.Scan(); ln++ {
+		if m := re.FindStringSubmatch(s.Text()); m != nil {
+			out = append(out, entry{
+				id: m[1], path: path, line: ln,
+				aspirational: aspirationalRe.MatchString(s.Text()),
+			})
+		}
+	}
+	return out, s.Err()
+}
+
+func main() {
+	var invariants, comments []entry
+	for _, f := range must(filepath.Glob(filepath.Join(invDir, "*.md"))) {
+		if b := filepath.Base(f); b == "README.md" || b == "COVERAGE.md" {
+			continue
+		}
+		es := must(scan(f, headerRe))
+		for i := range es {
+			es[i].module = strings.TrimSuffix(filepath.Base(f), ".md")
+		}
+		invariants = append(invariants, es...)
+	}
+	_ = filepath.Walk(".", func(p string, info os.FileInfo, err error) error {
+		if err != nil || !strings.HasSuffix(p, testSuffix) {
+			return nil
+		}
+		es := must(scan(p, commentRe))
+		for i := range es {
+			es[i].module = filepath.Base(filepath.Dir(p))
+		}
+		comments = append(comments, es...)
+		return nil
+	})
+
+	covered := map[string]bool{}
+	for _, c := range comments {
+		covered[c.module+"/"+c.id] = true
+	}
+	declared := map[string]bool{}
+	for _, i := range invariants {
+		declared[i.module+"/"+i.id] = true
+	}
+
+	var missing, orphans []entry
+	for _, i := range invariants {
+		if !i.aspirational && !covered[i.module+"/"+i.id] {
+			missing = append(missing, i)
+		}
+	}
+	for _, c := range comments {
+		if !declared[c.module+"/"+c.id] {
+			orphans = append(orphans, c)
+		}
+	}
+
+	if len(missing) == 0 && len(orphans) == 0 {
+		fmt.Println("invariant coverage OK")
+		return
+	}
+	if len(missing) > 0 {
+		fmt.Fprintln(os.Stderr, "Missing coverage — add `// Invariant <ID>: <Name>` above the property test:")
+		for _, m := range missing {
+			fmt.Fprintf(os.Stderr, "  - %s/%s declared at %s:%d (no covering test)\n", m.module, m.id, m.path, m.line)
+		}
+	}
+	if len(orphans) > 0 {
+		fmt.Fprintln(os.Stderr, "Orphan test comments — ID not declared in any invariant doc:")
+		for _, o := range orphans {
+			fmt.Fprintf(os.Stderr, "  - %s/%s at %s:%d\n", o.module, o.id, o.path, o.line)
+		}
+	}
+	fmt.Fprintln(os.Stderr, "\nFix: add the missing comment, remove the orphan, or mark the invariant `<!-- aspirational -->` in its doc header.")
+	os.Exit(1)
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(2)
+	}
+	return v
+}
+```
+
+Replace `<test-suffix>` with the detected suffix (e.g. `_invariants_prop_test.go`). Dependency-free — standard library only. Requires Go 1.18+ for generics.
+
+## Pre-commit
+
+**pre-commit.com (`.pre-commit-config.yaml`):**
+
+```yaml
+- repo: local
+  hooks:
+    - id: invariant-coverage
+      name: Invariant coverage (Go)
+      entry: go run scripts/check_invariant_coverage.go
+      language: system
+      pass_filenames: false
+      files: '^(docs/invariants/.*\.md|.*_invariants_prop_test\.go)$'
+```
+
+**lefthook (`lefthook.yml`):** add under `pre-commit.commands.invariant-coverage` with `glob: 'docs/invariants/*.md,**/*_invariants_prop_test.go'` and `run: go run scripts/check_invariant_coverage.go`.
+
+**husky (`.husky/pre-commit`):** append `go run scripts/check_invariant_coverage.go || exit 1`.
+
+**Standalone (`scripts/pre-commit-invariant-coverage.sh`):** `#!/usr/bin/env bash`, `set -euo pipefail`, then the `go run` line. Wire via `git config core.hooksPath .githooks` plus a symlink.
+
+## CI
+
+**GitHub Actions (`.github/workflows/invariant-coverage.yml`):**
+
+```yaml
+name: invariant-coverage
+on: [pull_request, push]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.22' }
+      - run: go run scripts/check_invariant_coverage.go
+```
+
+**GitLab CI (`.gitlab-ci.yml` job):**
+
+```yaml
+invariant-coverage:
+  image: golang:1.22
+  script: [go run scripts/check_invariant_coverage.go]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH
+```
+
+## Error Message
+
+On failure the script prints to stderr:
+
+```
+Missing coverage — add `// Invariant <ID>: <Name>` above the property test:
+  - queue/I1 declared at docs/invariants/queue.md:42 (no covering test)
+
+Orphan test comments — ID not declared in any invariant doc:
+  - runner/IX at cli/internal/runner/runner_invariants_prop_test.go:88
+
+Fix: add the missing comment, remove the orphan, or mark the invariant `<!-- aspirational -->` in its doc header.
+```
+
+The fix command is embedded so an AI coding agent reading the failure can act without human translation.

--- a/crosscheck/skills/invariant-coverage-scaffold/references/python-template.md
+++ b/crosscheck/skills/invariant-coverage-scaffold/references/python-template.md
@@ -1,0 +1,165 @@
+# Python Template — Invariant Coverage Gate
+
+Emit a Python script that parses invariant IDs from `docs/invariants/**/*.md` and cross-checks them against `// Invariant <ID>: <Name>` (or `# Invariant <ID>: <Name>`) comments in the repo's test files. Placeholders are marked `<placeholder>`.
+
+## Script Template
+
+Write to `scripts/check_invariant_coverage.py` and `chmod +x`.
+
+```python
+#!/usr/bin/env python3
+"""Bidirectional invariant-to-test coverage gate. Exits 0 ok, 1 on gap, 2 on error."""
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+from dataclasses import dataclass
+
+HEADER_RE = re.compile(r"^\*\*([A-Z]+\d+[a-z]?)\.\s")             # **I1. Name.**
+COMMENT_RE = re.compile(r"^\s*(?://|#)\s*Invariant\s+([A-Z]+\d+[a-z]?):\s")
+ASPIRATIONAL_RE = re.compile(r"<!--\s*aspirational\s*-->")
+
+TEST_GLOBS: list[str] = ["<test-glob>"]  # e.g. ["tests/**/*_invariants_test.py"]
+INVARIANT_DIR = pathlib.Path("docs/invariants")
+
+
+@dataclass(frozen=True)
+class Entry:
+    module: str
+    id: str
+    path: pathlib.Path
+    line: int
+    aspirational: bool = False
+
+
+def scan(path: pathlib.Path, pattern: re.Pattern[str], module: str) -> list[Entry]:
+    out: list[Entry] = []
+    for lineno, line in enumerate(path.read_text(errors="replace").splitlines(), start=1):
+        m = pattern.match(line)
+        if m:
+            out.append(Entry(module, m.group(1), path, lineno, bool(ASPIRATIONAL_RE.search(line))))
+    return out
+
+
+def parse_invariants() -> list[Entry]:
+    out: list[Entry] = []
+    for doc in sorted(INVARIANT_DIR.glob("*.md")):
+        if doc.name in {"README.md", "COVERAGE.md"}:
+            continue
+        out.extend(scan(doc, HEADER_RE, module=doc.stem))
+    return out
+
+
+def parse_comments() -> list[Entry]:
+    out: list[Entry] = []
+    seen: set[pathlib.Path] = set()
+    for glob in TEST_GLOBS:
+        for path in sorted(pathlib.Path(".").glob(glob)):
+            if path in seen or not path.is_file():
+                continue
+            seen.add(path)
+            out.extend(scan(path, COMMENT_RE, module=path.parent.name))
+    return out
+
+
+def main() -> int:
+    if not INVARIANT_DIR.is_dir():
+        print(f"error: {INVARIANT_DIR} not found", file=sys.stderr)
+        return 2
+    invariants = parse_invariants()
+    comments = parse_comments()
+    covered = {(c.module, c.id) for c in comments}
+    declared = {(i.module, i.id) for i in invariants}
+    missing = [i for i in invariants if not i.aspirational and (i.module, i.id) not in covered]
+    orphans = [c for c in comments if (c.module, c.id) not in declared]
+
+    if not missing and not orphans:
+        print("invariant coverage OK")
+        return 0
+    if missing:
+        print("Missing coverage — add `// Invariant <ID>: <Name>` above the property test:", file=sys.stderr)
+        for i in missing:
+            print(f"  - {i.module}/{i.id} declared at {i.path}:{i.line} (no covering test)", file=sys.stderr)
+    if orphans:
+        print("Orphan test comments — ID not declared in any invariant doc:", file=sys.stderr)
+        for c in orphans:
+            print(f"  - {c.module}/{c.id} at {c.path}:{c.line}", file=sys.stderr)
+    print(
+        "\nFix: add the missing comment, remove the orphan, "
+        "or mark the invariant `<!-- aspirational -->` in its doc header.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Replace `<test-glob>` with the detected glob (e.g. `tests/**/*_invariants_test.py`). Standard library only — no runtime deps.
+
+## Pre-commit
+
+**pre-commit.com (`.pre-commit-config.yaml`):**
+
+```yaml
+- repo: local
+  hooks:
+    - id: invariant-coverage
+      name: Invariant coverage (Python)
+      entry: python3 scripts/check_invariant_coverage.py
+      language: system
+      pass_filenames: false
+      files: '^(docs/invariants/.*\.md|tests/.*_invariants_test\.py)$'
+```
+
+**lefthook (`lefthook.yml`):** add under `pre-commit.commands.invariant-coverage` with `glob: 'docs/invariants/*.md,tests/**/*_invariants_test.py'` and `run: python3 scripts/check_invariant_coverage.py`.
+
+**husky (`.husky/pre-commit`):** append `python3 scripts/check_invariant_coverage.py || exit 1`.
+
+**Standalone (`scripts/pre-commit-invariant-coverage.sh`):** `#!/usr/bin/env bash`, `set -euo pipefail`, then the `python3` line. Wire via `git config core.hooksPath .githooks` plus a symlink.
+
+## CI
+
+**GitHub Actions (`.github/workflows/invariant-coverage.yml`):**
+
+```yaml
+name: invariant-coverage
+on: [pull_request, push]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.11' }
+      - run: python3 scripts/check_invariant_coverage.py
+```
+
+**GitLab CI (`.gitlab-ci.yml` job):**
+
+```yaml
+invariant-coverage:
+  image: python:3.11-slim
+  script: [python3 scripts/check_invariant_coverage.py]
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH
+```
+
+## Error Message
+
+On failure the script prints to stderr:
+
+```
+Missing coverage — add `// Invariant <ID>: <Name>` above the property test:
+  - queue/I1 declared at docs/invariants/queue.md:42 (no covering test)
+
+Orphan test comments — ID not declared in any invariant doc:
+  - runner/IX at tests/runner/test_runner_invariants.py:88
+
+Fix: add the missing comment, remove the orphan, or mark the invariant `<!-- aspirational -->` in its doc header.
+```
+
+The fix command is embedded so an AI coding agent reading the failure can act without human translation.

--- a/crosscheck/skills/invariant-coverage-scaffold/references/typescript-template.md
+++ b/crosscheck/skills/invariant-coverage-scaffold/references/typescript-template.md
@@ -1,0 +1,164 @@
+# TypeScript Template — Invariant Coverage Gate
+
+Emit a TypeScript script that parses invariant IDs from `docs/invariants/**/*.md` and cross-checks them against `// Invariant <ID>: <Name>` comments in the repo's test files. Placeholders are marked `<placeholder>`.
+
+## Script Template
+
+Write to `scripts/check-invariant-coverage.ts` (runnable via `npx tsx`). Dependency-free — only Node built-ins.
+
+```ts
+#!/usr/bin/env npx tsx
+// Bidirectional invariant-to-test coverage gate. Exits 0 ok, 1 on gap.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, basename, dirname, extname } from "node:path";
+
+const HEADER_RE = /^\*\*([A-Z]+\d+[a-z]?)\.\s/;             // **I1. Name.**
+const COMMENT_RE = /^\s*\/\/\s*Invariant\s+([A-Z]+\d+[a-z]?):\s/;
+const ASPIRATIONAL_RE = /<!--\s*aspirational\s*-->/;
+
+// Replace with repo convention, e.g. [".invariants.test.ts", ".invariants.spec.ts"].
+const TEST_SUFFIXES: string[] = ["<test-suffix>"];
+const INVARIANT_DIR = "docs/invariants";
+const SKIP_DIRS = new Set(["node_modules", ".git", "dist", "build"]);
+
+type Entry = {
+  module: string;
+  id: string;
+  path: string;
+  line: number;
+  aspirational?: boolean;
+};
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) yield* walk(full);
+    else yield full;
+  }
+}
+
+function scan(path: string, re: RegExp, module: string): Entry[] {
+  const out: Entry[] = [];
+  readFileSync(path, "utf8").split("\n").forEach((line, i) => {
+    const m = re.exec(line);
+    if (m) out.push({ module, id: m[1], path, line: i + 1, aspirational: ASPIRATIONAL_RE.test(line) });
+  });
+  return out;
+}
+
+function parseInvariants(): Entry[] {
+  const out: Entry[] = [];
+  for (const entry of readdirSync(INVARIANT_DIR)) {
+    if (extname(entry) !== ".md" || entry === "README.md" || entry === "COVERAGE.md") continue;
+    out.push(...scan(join(INVARIANT_DIR, entry), HEADER_RE, basename(entry, ".md")));
+  }
+  return out;
+}
+
+function parseComments(): Entry[] {
+  const out: Entry[] = [];
+  for (const path of walk(".")) {
+    if (!TEST_SUFFIXES.some((s) => path.endsWith(s))) continue;
+    out.push(...scan(path, COMMENT_RE, basename(dirname(path))));
+  }
+  return out;
+}
+
+function main(): number {
+  const invariants = parseInvariants();
+  const comments = parseComments();
+  const covered = new Set(comments.map((c) => `${c.module}/${c.id}`));
+  const declared = new Set(invariants.map((i) => `${i.module}/${i.id}`));
+  const missing = invariants.filter((i) => !i.aspirational && !covered.has(`${i.module}/${i.id}`));
+  const orphans = comments.filter((c) => !declared.has(`${c.module}/${c.id}`));
+
+  if (missing.length === 0 && orphans.length === 0) {
+    console.log("invariant coverage OK");
+    return 0;
+  }
+  if (missing.length > 0) {
+    console.error("Missing coverage — add `// Invariant <ID>: <Name>` above the property test:");
+    for (const i of missing) console.error(`  - ${i.module}/${i.id} declared at ${i.path}:${i.line} (no covering test)`);
+  }
+  if (orphans.length > 0) {
+    console.error("Orphan test comments — ID not declared in any invariant doc:");
+    for (const c of orphans) console.error(`  - ${c.module}/${c.id} at ${c.path}:${c.line}`);
+  }
+  console.error("\nFix: add the missing comment, remove the orphan, or mark the invariant `<!-- aspirational -->` in its doc header.");
+  return 1;
+}
+
+process.exit(main());
+```
+
+Replace `<test-suffix>` with the repo convention (e.g. `.invariants.test.ts`). Works under `tsx`, `ts-node`, or Deno with minor tweaks.
+
+## Pre-commit
+
+**pre-commit.com (`.pre-commit-config.yaml`):**
+
+```yaml
+- repo: local
+  hooks:
+    - id: invariant-coverage
+      name: Invariant coverage (TypeScript)
+      entry: npx tsx scripts/check-invariant-coverage.ts
+      language: system
+      pass_filenames: false
+      files: '^(docs/invariants/.*\.md|.*\.invariants\.(test|spec)\.ts)$'
+```
+
+**lefthook (`lefthook.yml`):** add under `pre-commit.commands.invariant-coverage` with `glob: 'docs/invariants/*.md,**/*.invariants.test.ts,**/*.invariants.spec.ts'` and `run: npx tsx scripts/check-invariant-coverage.ts`.
+
+**husky (`.husky/pre-commit`):** append `npx tsx scripts/check-invariant-coverage.ts || exit 1`.
+
+**Standalone (`scripts/pre-commit-invariant-coverage.sh`):** `#!/usr/bin/env bash`, `set -euo pipefail`, then the `npx tsx` line. Wire via `git config core.hooksPath .githooks` plus a symlink.
+
+## CI
+
+**GitHub Actions (`.github/workflows/invariant-coverage.yml`):**
+
+```yaml
+name: invariant-coverage
+on: [pull_request, push]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+      - run: npm ci --ignore-scripts
+      - run: npx tsx scripts/check-invariant-coverage.ts
+```
+
+**GitLab CI (`.gitlab-ci.yml` job):**
+
+```yaml
+invariant-coverage:
+  image: node:20
+  script:
+    - npm ci --ignore-scripts
+    - npx tsx scripts/check-invariant-coverage.ts
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+    - if: $CI_COMMIT_BRANCH
+```
+
+## Error Message
+
+On failure the script prints to stderr:
+
+```
+Missing coverage — add `// Invariant <ID>: <Name>` above the property test:
+  - queue/I1 declared at docs/invariants/queue.md:42 (no covering test)
+
+Orphan test comments — ID not declared in any invariant doc:
+  - runner/IX at src/runner/runner.invariants.test.ts:88
+
+Fix: add the missing comment, remove the orphan, or mark the invariant `<!-- aspirational -->` in its doc header.
+```
+
+The fix command is embedded so an AI coding agent reading the failure can act without human translation.


### PR DESCRIPTION
## Summary

- New skill `/invariant-coverage-scaffold` that generates the bidirectional invariant-to-test coverage gate in a target repo, adapted to the detected language and tooling.
- Emits both a pre-commit hook and a CI job (dual-track enforcement principle from the assurance-hierarchy plan).
- v1 language coverage: Go, Python, TypeScript. Rust, Ruby, Java are explicitly deferred.
- Three reference templates under `references/` contain the full script body, pre-commit config for pre-commit.com/lefthook/husky/standalone, and CI snippets for GitHub Actions and GitLab CI.

This is unit #6 of 10 in the assurance-hierarchy skill-suite batch (plan: `~/.claude/plans/temporal-orbiting-turing.md`).

## Test plan

- [x] Frontmatter lint (`name`, `description`, `argument-hint` present).
- [x] Structure lint: `## Description`, `## Instructions`, `## Arguments`, Verification Checklist all present in SKILL.md; each reference file has `Script Template`, `Pre-commit`, `CI`, `Error Message` sections.
- [x] Git status shows only the four new files under `crosscheck/skills/invariant-coverage-scaffold/` — no changes outside the skill directory.
- [ ] Invoke-smoke: NOT POSSIBLE from this worker environment (no Claude Code session with the plugin loaded in sandbox). Manual smoke after merge: run `/invariant-coverage-scaffold` in a Go/Python/TS project and confirm language detection + correct template reference.

## Notes for reviewer

- Acceptance criteria from the plan (invariants without tests → fail; orphan comments → fail; aspirational marker respected; < 10 s on ~200 invariants) are encoded in the skill's Verification Checklist.
- The `<\!-- aspirational -->` opt-out marker matches the xylem convention (`docs/invariants/README.md`).
- Scripts in each template are dependency-free (stdlib only) so pre-commit stays under the 5 s budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)