### PR TITLE
feat(crosscheck): add /intent-check skill

### DIFF
--- a/crosscheck/skills/intent-check/SKILL.md
+++ b/crosscheck/skills/intent-check/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: intent-check
+description: >-
+  Portable round-trip informalization over (invariant prose, covering test,
+  code diff) — Layer 5 of the assurance hierarchy. Runs a two-LLM pipeline
+  (blind back-translator then diff-checker), appends outcomes to a
+  false-positive tracker, emits a content-addressed JSON attestation, and
+  enforces a 30% FP kill criterion. Triggers: "intent check", "round-trip
+  check", "spec-intent alignment", "verify invariant against test",
+  protected-surface diffs touching `docs/invariants/` or property tests.
+argument-hint: "[optional: invariant doc path] [optional: covering test path]"
+---
+
+# /intent-check — Round-Trip Intent Verification
+
+## Description
+
+Operationalise Layer 5 (spec-intent alignment) of the assurance hierarchy as a portable, repo-agnostic Claude Code skill. The input is a triple — an **invariant prose description**, a **covering property test**, and the **code diff** the user wants to ship. The output is a structured verdict (match / mismatch + confidence + reason), an appended row in a per-repo false-positive tracker CSV, and a content-hashed JSON attestation that a companion pre-commit hook can check without invoking an LLM.
+
+The skill is a portable analog of Midspiral's `claimcheck` and xylem's `xylem-intent-check` binary. It is structurally adversarial by construction: the back-translator is **blind to the original intent prose**, so it cannot tautologically restate it, and the diff-checker is forced to scan for carve-outs and rationale comments before rendering a verdict. These two prompt-level guardrails are the Phase-1 calibration fixes that drive the false-positive rate below the 30% kill criterion.
+
+This is a methodology skill. It does not ship a binary — Claude drives the pipeline itself, reading files, invoking the two prompts in the required order, writing the tracker row and the attestation, and running the kill-criterion math before committing. The companion pre-commit hook (described in `references/attestation-schema.md`) is fast and LLM-free: it only checks hashes and verdicts.
+
+Cross-references:
+- `references/round-trip-prompt.md` — verbatim two-prompt template for back-translator + diff-checker, including rationale extraction and carve-out taxonomy.
+- `references/fp-tracker-schema.md` — CSV schema, append logic, and the 30% kill-criterion computation.
+- `references/attestation-schema.md` — JSON attestation format, SHA-256 computation, and pre-commit hook pseudocode.
+
+## Instructions
+
+You are running a two-LLM round-trip informalization pipeline over one protected-surface change. The structural separation between back-translator and diff-checker is the entire point — do not shortcut it, do not let the same reasoning thread produce both outputs, and do not allow the back-translator to see the invariant prose.
+
+### Step 0: Kill-Criterion Pre-Check
+
+Before doing any LLM work, open `.assurance/intent-check-fp-tracker.csv` (create it if missing; see `references/fp-tracker-schema.md` for the exact header).
+
+Compute the rolling false-positive rate over the **last 2 weeks of entries** (rows where `date` is within 14 days of today):
+
+- FP rate = count(`human_verdict` == `spurious`) / count(all rows in window)
+- If the window has fewer than 3 rows, treat the rate as unknown and proceed with a warning.
+- If the FP rate **> 30%**, refuse to run. Tell the user:
+
+  > The Layer-5 round-trip pipeline's rolling false-positive rate is `<rate>%` over the last 14 days (threshold: 30%). The kill criterion in the assurance hierarchy says this layer's strategy needs rework before it keeps gating commits. Do not re-enable until (a) the prompt or model is revised, or (b) human review has reclassified enough entries to drop the rate below 30%. See `references/fp-tracker-schema.md` for the exact computation.
+
+  Stop. Do not proceed to Step 1.
+
+### Step 1: Gather the Triple
+
+Determine the three inputs:
+
+1. **Invariant prose.** Default location: `docs/invariants/<module>.md`. If the user named a specific module or file, use that. If multiple invariant docs are touched by the diff, ask the user which one to focus on — run the pipeline once per (invariant, test, diff) triple.
+2. **Covering property test.** The test file(s) that exercise the invariant. Prefer tests whose comments reference the invariant ID (e.g. `// I2:` or `// invariant I2`). If you cannot identify a covering test, stop and tell the user — the pipeline is undefined without one.
+3. **Code diff.** Staged changes in the current working tree: `git diff --staged` plus any relevant already-committed changes on the branch. Scope the diff to files implicated by the invariant — not the entire PR.
+
+If any of the three is missing, ask the user to supply it (path or inline) before proceeding. Do not guess.
+
+Record the set of **protected files** touched by this run — the union of the invariant doc paths, the covering test paths, and any code files that the invariant doc explicitly protects. This set is later written into the attestation as `protected_files`.
+
+### Step 2: Run the Back-Translator (BLIND Prompt)
+
+Use the `back_translate` prompt verbatim from `references/round-trip-prompt.md`. Fill the `{code}` and `{test}` placeholders only. **Do not include the invariant prose** — passing it through contaminates the back-translator and voids the round-trip property.
+
+The back-translator must output **two sections**:
+
+- **Section 1: Behavioural guarantees** — a plain-text paragraph describing what the code + test enforce.
+- **Section 2: Design rationale comments** — every 3+ line comment block and every single-line comment whose text contains rationale markers (`because`, `since`, `artefact`, `workaround`, `zeroed`, `intentional`, `skipping`, `ignore`), quoted verbatim with file and line references. If none exist, the section must say `None.`.
+
+Both sections are mandatory. If either is missing or empty (other than the explicit `None.`), re-invoke the prompt once. If it is still malformed on the second try, stop and report the failure.
+
+### Step 3: Run the Diff-Checker
+
+Use the `diff_check` prompt verbatim from `references/round-trip-prompt.md`. Supply:
+
+- `{invariant_prose}` — the full relevant section of the invariant doc (the specific invariant(s) the test covers, not the entire doc).
+- `{back_translation}` — both sections from Step 2, unedited.
+
+The prompt forces the diff-checker to do a **mandatory Step 1 carve-out scan** before evaluating any gap. The scan looks for scope markers — `Not covered`, `caller-responsibility`, `precondition`, `aspirational`, `known violation`, `privileged`, `exempt`, `out of scope`, `does not apply` — and classifies each found clause by the scope-modifier taxonomy documented in the prompt template. Only after the scan does the prompt evaluate apparent gaps.
+
+The diff-checker returns a JSON object matching this schema:
+
+```json
+{
+  "match": true | false,
+  "mismatch_reason": "string",
+  "mismatch_category": "spec_scope_mismatch | weaker_guarantee | missing_property | missing_coverage | rationale_explains | carve_out_applies | clean_match",
+  "confidence_pct": 0-100,
+  "confidence_basis": "carve-out-found | rationale-found | rationale-absent | spec-ambiguous | code-ambiguous"
+}
+```
+
+### Step 4: Semantic Validation (fail-closed hardening)
+
+After parsing the diff-checker JSON, apply these two defensive rules (they are independent of the prompt so they catch model contradictions):
+
+1. **Contradictory output.** If `match == true` AND `mismatch_reason` is non-empty and non-trivial → flip to:
+   ```
+   match = false
+   confidence_pct = 40
+   confidence_basis = "spec-ambiguous"
+   mismatch_category = "missing_property"
+   ```
+   Record a note that the raw output was internally contradictory. Fail-closed is safer than trusting either half of the contradiction.
+2. **Truncated reason.** If `match == false` AND `len(strip(mismatch_reason)) < 20` → reject the output as truncation. Do not write a tracker row or an attestation. Ask the user to re-run (network transient / model returned malformed result).
+
+If either rule trips, surface the raw pre-rule output alongside the post-rule decision so the user can audit.
+
+### Step 5: Append to the FP Tracker
+
+Append exactly one row to `.assurance/intent-check-fp-tracker.csv` with columns:
+
+```
+date,invariant_touched,phase_verdict,human_verdict
+```
+
+- `date` — today in `YYYY-MM-DD`.
+- `invariant_touched` — a short label identifying the invariant under test, e.g. `queue.md I2 (6-of-19 field mutation coverage)`. Match the style of the xylem tracker (see `references/fp-tracker-schema.md`).
+- `phase_verdict` — `pass` if `match == true`, `fail` otherwise.
+- `human_verdict` — leave **empty** at skill-run time. A human reviewer fills this in later as `genuine`, `genuine-planted`, `partial`, or `spurious`. The kill-criterion math ignores empty cells (see `references/fp-tracker-schema.md` for the append logic and the rolling-window computation).
+
+The schema matches xylem's CSV verbatim — this is the plan's "adopt plan defaults" decision. Do not add columns; do not rename columns.
+
+### Step 6: Write the Attestation
+
+Compute the `content_hash` of the protected-file set:
+
+1. Sort `protected_files` alphabetically.
+2. Read each file as raw bytes in that order and concatenate with no delimiter.
+3. SHA-256 the concatenated byte stream; hex-encode lowercase.
+
+Write `.assurance/intent-check-attestation.json` with the schema documented in `references/attestation-schema.md`:
+
+```json
+{
+  "protected_files": ["…sorted…"],
+  "content_hash": "<64-hex-chars>",
+  "verdict": "pass" | "fail",
+  "checked_at": "<RFC3339 timestamp>",
+  "pipeline_output": {
+    "back_translation": "…Section 1 + Section 2 verbatim…",
+    "diff_result": { …full JSON from Step 4 post-validation… }
+  }
+}
+```
+
+`verdict` mirrors `phase_verdict`: `pass` if `match == true` **and** `confidence_pct >= 80`, otherwise `fail`. Low-confidence matches do not count as clean passes — the attestation says `fail` and the user can override with a documented governance note (use `/protected-surface-amend`).
+
+The attestation must be written **before** the commit that touches the protected files. The companion pre-commit hook (described in `references/attestation-schema.md`) re-reads the protected files, recomputes the hash, and fails the commit if the attestation is absent, stale, or the verdict is not `pass`.
+
+### Step 7: Companion Pre-Commit Hook (describe, don't install)
+
+The skill does not install the hook for the user — installing hooks is a repo-level governance decision. But it must **describe** the hook so the user can wire it up. Point the user at `references/attestation-schema.md`, which contains the full pseudocode. Summarise in two lines:
+
+> A fast pre-commit hook (< 1 s, no LLM) that scans staged files for any match to the protected-surface patterns, and — if found — reads `.assurance/intent-check-attestation.json`, recomputes the content hash, and rejects the commit unless the attestation exists, its verdict is `pass`, and its hash matches. The hook is installed once per repo and calls `/intent-check` only when the user re-runs it manually.
+
+### Step 8: Report
+
+Present a single summary block to the user:
+
+```
+## /intent-check verdict: <pass|fail>
+
+- Invariant: <label>
+- Match: <true|false>
+- Confidence: <pct>% (basis: <basis>)
+- Category: <mismatch_category>
+- Reason: <mismatch_reason or "clean match">
+
+Tracker row appended: .assurance/intent-check-fp-tracker.csv
+Attestation written:   .assurance/intent-check-attestation.json
+
+Rolling 14-day FP rate: <rate>% (threshold 30%)
+```
+
+If `match == false`, tell the user exactly what the back-translator perceived vs. what the invariant prose claimed, so they can decide whether to fix the code, fix the test, or amend the invariant prose via `/protected-surface-amend`.
+
+### Verification Checklist
+
+```
+## Verification Checklist
+
+- [ ] Kill-criterion pre-check ran before any LLM call (rolling 14-day FP rate < 30%)
+- [ ] Back-translator prompt received only {code, test} — never the invariant prose
+- [ ] Back-translation contains both Section 1 (behavioural guarantees) and Section 2 (rationale comments, verbatim with file:line)
+- [ ] Diff-checker performed the mandatory Step 1 carve-out scan before rendering a verdict
+- [ ] Diff-checker output passes semantic validation (no contradictory match/reason, reason >= 20 chars when non-empty)
+- [ ] FP-tracker row appended with the exact xylem schema (date, invariant_touched, phase_verdict, human_verdict)
+- [ ] Attestation emitted with sorted protected_files, SHA-256 content_hash, verdict, RFC3339 checked_at, and pipeline_output
+- [ ] Pre-commit hook behaviour described (not installed) so the user can wire it up via their hook config
+- [ ] User given the remediation path if verdict is fail (fix code / fix test / amend invariant with /protected-surface-amend)
+```
+
+## Arguments
+
+Optional invariant-doc path and covering-test path. Omitted arguments prompt the skill to locate them itself.
+
+Examples:
+- `/intent-check` — locate the triple from staged changes and recent context.
+- `/intent-check docs/invariants/queue.md` — run against all covering tests for that invariant doc.
+- `/intent-check docs/invariants/queue.md internal/queue/queue_invariants_prop_test.go` — explicit triple; code diff taken from `git diff --staged`.

--- a/crosscheck/skills/intent-check/SKILL.md
+++ b/crosscheck/skills/intent-check/SKILL.md
@@ -34,10 +34,10 @@ You are running a two-LLM round-trip informalization pipeline over one protected
 
 Before doing any LLM work, open `.assurance/intent-check-fp-tracker.csv` (create it if missing; see `references/fp-tracker-schema.md` for the exact header).
 
-Compute the rolling false-positive rate over the **last 2 weeks of entries** (rows where `date` is within 14 days of today):
+Compute the rolling false-positive rate over the **last 2 weeks of entries** (rows where `date` is within 14 days of today **AND `human_verdict` is non-empty** — empty cells are awaiting review and are excluded from both numerator and denominator; see the pseudocode in `references/fp-tracker-schema.md`):
 
-- FP rate = count(`human_verdict` == `spurious`) / count(all rows in window)
-- If the window has fewer than 3 rows, treat the rate as unknown and proceed with a warning.
+- FP rate = count(`human_verdict` == `spurious`) / count(rows in window with non-empty `human_verdict`)
+- If the window has fewer than 3 classified rows, treat the rate as unknown and proceed with a warning.
 - If the FP rate **> 30%**, refuse to run. Tell the user:
 
   > The Layer-5 round-trip pipeline's rolling false-positive rate is `<rate>%` over the last 14 days (threshold: 30%). The kill criterion in the assurance hierarchy says this layer's strategy needs rework before it keeps gating commits. Do not re-enable until (a) the prompt or model is revised, or (b) human review has reclassified enough entries to drop the rate below 30%. See `references/fp-tracker-schema.md` for the exact computation.
@@ -114,7 +114,7 @@ date,invariant_touched,phase_verdict,human_verdict
 
 - `date` — today in `YYYY-MM-DD`.
 - `invariant_touched` — a short label identifying the invariant under test, e.g. `queue.md I2 (6-of-19 field mutation coverage)`. Match the style of the xylem tracker (see `references/fp-tracker-schema.md`).
-- `phase_verdict` — `pass` if `match == true`, `fail` otherwise.
+- `phase_verdict` — `pass` if `match == true` **AND** `confidence_pct >= 80`; `fail` otherwise. This must match the `verdict` written to the attestation in Step 6 — low-confidence matches are tracked as `fail` so the kill criterion picks up prompt weakness, and the attestation hook refuses the commit.
 - `human_verdict` — leave **empty** at skill-run time. A human reviewer fills this in later as `genuine`, `genuine-planted`, `partial`, or `spurious`. The kill-criterion math ignores empty cells (see `references/fp-tracker-schema.md` for the append logic and the rolling-window computation).
 
 The schema matches xylem's CSV verbatim — this is the plan's "adopt plan defaults" decision. Do not add columns; do not rename columns.

--- a/crosscheck/skills/intent-check/references/attestation-schema.md
+++ b/crosscheck/skills/intent-check/references/attestation-schema.md
@@ -1,0 +1,193 @@
+# Attestation schema — JSON format, SHA-256 computation, pre-commit hook
+
+`/intent-check` writes `.assurance/intent-check-attestation.json` on every run. The attestation is the deterministic, LLM-free record that a companion pre-commit hook uses to decide whether a commit touching protected-surface files is allowed.
+
+The pattern is lifted from xylem (`/Users/harry.nicholls/repos/xylem/docs/assurance/next/07-intent-check-phase.md`, lines 34–58) and generalised so any repo can adopt it without a Go binary.
+
+## Why an attestation (not just a CI job)
+
+A CI-only enforcement leaves a window in which a developer can push a broken spec-intent pairing and only learn about it minutes later, blocking their merge. A **pre-commit attestation** enforces the rule at the earliest possible moment, and — crucially — it does so without invoking an LLM. LLMs are slow, non-deterministic, and expensive; pre-commit hooks must be all three opposite.
+
+The trick is the content-hash binding: the attestation records a SHA-256 of the protected files at the moment the LLM pipeline ran, and the pre-commit hook recomputes that hash from the current file contents. Any unexplained change to a protected file between `/intent-check` and `git commit` invalidates the attestation and rejects the commit.
+
+## Schema
+
+```json
+{
+  "protected_files":  ["<sorted-paths-relative-to-repo-root>"],
+  "content_hash":     "<lowercase-hex-sha256>",
+  "verdict":          "pass" | "fail",
+  "checked_at":       "<RFC3339 timestamp>",
+  "pipeline_output":  {
+    "back_translation": "<Section 1 + Section 2 verbatim>",
+    "diff_result": {
+      "match":              true | false,
+      "mismatch_reason":    "<string>",
+      "mismatch_category":  "<enum>",
+      "confidence_pct":     0-100,
+      "confidence_basis":   "<enum>"
+    }
+  }
+}
+```
+
+| Field                            | Required | Description                                                                                                                                                       |
+|----------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `protected_files`                | yes      | Alphabetically sorted list of repo-relative paths touched by this pipeline run. Forms the input to the content hash.                                              |
+| `content_hash`                   | yes      | Lowercase hex SHA-256 of `concat(read_bytes(f) for f in protected_files)` with **no** delimiter between files. Order matches `protected_files`.                   |
+| `verdict`                        | yes      | `pass` if the diff-checker returned `match=true` AND `confidence_pct>=80`; otherwise `fail`. Low-confidence matches are not passes.                                |
+| `checked_at`                     | yes      | RFC3339 timestamp in UTC (e.g. `2026-04-24T14:32:10Z`). Used by external tooling to detect stale attestations beyond pre-commit scope.                            |
+| `pipeline_output.back_translation` | yes    | Section 1 + Section 2 from the blind back-translator, verbatim. Making this human-readable is a deliberate forgery-cost decision — see "why the pipeline output is a field".     |
+| `pipeline_output.diff_result`    | yes      | Full JSON object from the diff-checker after semantic validation (not the raw pre-validation output).                                                            |
+
+Unknown/extra fields are tolerated by the pre-commit hook for forward compatibility but SHOULD NOT be added without updating this doc and the skill's verification checklist.
+
+## Example
+
+```json
+{
+  "protected_files": [
+    "docs/invariants/queue.md",
+    "internal/queue/queue.go",
+    "internal/queue/queue_invariants_prop_test.go"
+  ],
+  "content_hash": "9c3b1f1e2d1b4a3a6c4b9e5d2c1b4a3a6c4b9e5d2c1b4a3a6c4b9e5d2c1b4a3a",
+  "verdict": "pass",
+  "checked_at": "2026-04-24T14:32:10Z",
+  "pipeline_output": {
+    "back_translation": "### Section 1: Behavioural guarantees\nThe test enforces that enqueue followed by dequeue preserves payload ordering under single-writer concurrency… \n\n### Section 2: Design rationale comments\nqueue_invariants_prop_test.go:452-457\n> Clock values are zeroed before equality comparison because wall-clock drift between reference run and crash run is a test-infrastructure artefact.",
+    "diff_result": {
+      "match": true,
+      "mismatch_reason": "",
+      "mismatch_category": "clean_match",
+      "confidence_pct": 92,
+      "confidence_basis": "rationale-found"
+    }
+  }
+}
+```
+
+## SHA-256 computation (exact)
+
+The hash binds the attestation to the specific byte contents of the protected files at the time of the run. Any subsequent edit to any protected file invalidates the attestation until `/intent-check` is re-run.
+
+Algorithm:
+
+```python
+import hashlib
+
+def content_hash(repo_root: str, protected_files: list[str]) -> str:
+    h = hashlib.sha256()
+    for rel_path in sorted(protected_files):  # sort BEFORE hashing, always
+        with open(f"{repo_root}/{rel_path}", "rb") as f:
+            h.update(f.read())  # NO delimiter, NO newline padding
+    return h.hexdigest()
+```
+
+Invariants of the algorithm:
+
+1. Sort `protected_files` alphabetically using locale-independent ordering (bytewise). The sorted list is what goes into the attestation AND into the hash. The sort is what makes the hash independent of the order files were discovered in.
+2. Concatenate raw file bytes with **no delimiter**. Adding a delimiter (newline, null byte, filename prefix) would be fine, but the choice must stay fixed — the pre-commit hook must use the same algorithm. We pick "no delimiter" for simplicity; the file boundaries are implicit in the manifest (`protected_files`) and the hash only needs to be unique per (file-set, byte-content) pair.
+3. Hex-encode the digest in lowercase. Case matters for hook equality comparison.
+
+## Pre-commit hook (pseudocode; fast, no LLM)
+
+Design target: < 1 second wall-clock on a typical repo. The hook runs on every commit, so even a few hundred milliseconds is perceptible.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+ATTESTATION=".assurance/intent-check-attestation.json"
+PATTERNS_FILE=".claude/rules/protected-surfaces.md"   # or a .gitignore-style pattern list
+
+# Step 1: Identify staged protected files.
+staged="$(git diff --cached --name-only --diff-filter=ACMR)"
+protected_staged="$(echo "$staged" | grep_against_patterns "$PATTERNS_FILE" || true)"
+
+# Step 2: Fast exit if no protected files were touched.
+if [[ -z "$protected_staged" ]]; then
+    exit 0
+fi
+
+# Step 3: Attestation must exist.
+if [[ ! -f "$ATTESTATION" ]]; then
+    echo "intent-check attestation missing. Run /intent-check and stage ${ATTESTATION} before committing." >&2
+    exit 1
+fi
+
+# Step 4: Verdict must be pass.
+verdict="$(jq -r '.verdict' "$ATTESTATION")"
+if [[ "$verdict" != "pass" ]]; then
+    echo "intent-check attestation verdict is '${verdict}' (expected 'pass'). Re-run /intent-check and resolve the mismatch." >&2
+    exit 1
+fi
+
+# Step 5: Recompute content hash over the attestation's protected_files.
+claimed_files="$(jq -r '.protected_files[]' "$ATTESTATION" | sort)"
+claimed_hash="$(jq -r '.content_hash' "$ATTESTATION")"
+actual_hash="$(cat $claimed_files | sha256sum | awk '{print $1}')"
+
+if [[ "$actual_hash" != "$claimed_hash" ]]; then
+    echo "intent-check attestation is stale — protected files have changed since the last run." >&2
+    echo "  claimed: $claimed_hash" >&2
+    echo "  actual:  $actual_hash" >&2
+    echo "Re-run /intent-check and re-stage ${ATTESTATION}." >&2
+    exit 1
+fi
+
+# Step 6: Ensure every staged protected file is in the attestation's set.
+for f in $protected_staged; do
+    if ! grep -qx "$f" <<<"$claimed_files"; then
+        echo "intent-check attestation does not cover staged file: $f" >&2
+        echo "Re-run /intent-check with the full set of protected files staged." >&2
+        exit 1
+    fi
+done
+
+exit 0
+```
+
+Notes on the pseudocode:
+
+- `grep_against_patterns` is a placeholder for whatever the repo uses to match a path list against its `protected-surfaces.md` patterns. Most repos parse the section headers + bullet paths from that file; some use a dedicated `.protected-surfaces` list.
+- `cat $claimed_files | sha256sum` replicates the "concat with no delimiter" rule. On repos with large protected files, use a streamed `sha256sum` loop to avoid memory spikes.
+- The hook only checks files already in the attestation — if a staged protected file is missing from `protected_files`, Step 6 rejects the commit. This prevents partial-coverage exploits.
+- The hook must not invoke `/intent-check` itself, must not call network, must not shell out to any LLM tool. It is deterministic by design.
+
+## Registering the hook
+
+The skill **describes** the hook but does **not install** it — installing hooks is a governance decision per repo. Tell the user to wire it up via their existing hook manager:
+
+- **pre-commit (Python):** add a local repo stanza in `.pre-commit-config.yaml`:
+  ```yaml
+  - repo: local
+    hooks:
+      - id: intent-check-attestation
+        name: intent-check attestation
+        entry: scripts/check-intent-attestation.sh
+        language: system
+        pass_filenames: false
+        stages: [commit]
+  ```
+- **lefthook:** add under `pre-commit.commands.intent-check-attestation`.
+- **husky / simple-git-hooks:** add to the `pre-commit` command in `package.json`.
+- **bare `.git/hooks/pre-commit`:** the simplest path. Copy the script to `.git/hooks/pre-commit` and `chmod +x` it. Not portable across fresh clones — prefer a managed hook.
+
+## Why `pipeline_output` is a field (forgery cost)
+
+An attentive reader will notice the `pipeline_output` field is semantically redundant — the pre-commit hook doesn't read it, only the hash + verdict. It lives in the attestation deliberately:
+
+- **Forgery cost.** For an LLM (or a human) to forge a passing attestation without running the pipeline, they would need to (a) compute the correct SHA-256 over the exact file contents in the correct sort order, (b) produce a plausible `pipeline_output` matching what the back-translator would actually generate, and (c) JSON-encode it correctly. Part (b) is the load-bearing friction — it is cheaper to re-run `/intent-check` than to fabricate believable back-translation prose.
+- **Human review.** When a reviewer audits whether a verdict is right, they can read the back-translation + diff result without re-running the pipeline.
+- **Tracker reconciliation.** When a human fills the `human_verdict` column in the FP tracker, they need the verdict context. The attestation + tracker row together give them enough to decide.
+
+## Interaction with `/protected-surface-amend`
+
+If a reviewer decides that a `fail` verdict is actually the result of an intentional spec evolution rather than a drift, the correct remediation is NOT to hand-edit the attestation to `pass`. It is to:
+
+1. Run `/protected-surface-amend` to produce the governance-note amendment block.
+2. Amend the invariant prose (or the covering test) so that the next `/intent-check` run legitimately returns `match=true`.
+3. Re-run `/intent-check` to get a fresh, legitimately-passing attestation.
+
+Hand-editing the attestation is a governance bypass and should be blocked by the pre-commit hook's hash check in any case (the hash won't match).

--- a/crosscheck/skills/intent-check/references/fp-tracker-schema.md
+++ b/crosscheck/skills/intent-check/references/fp-tracker-schema.md
@@ -1,0 +1,132 @@
+# FP tracker CSV — schema, append logic, kill-criterion computation
+
+`/intent-check` appends one row to `.assurance/intent-check-fp-tracker.csv` per pipeline run. The tracker is the only persistent record of round-trip verdicts and is the input to the 30% kill criterion that decides whether Layer 5 stays online.
+
+The schema matches the xylem tracker at `/Users/harry.nicholls/repos/xylem/docs/assurance/next/07-fp-tracker.csv` verbatim. Parity is deliberate — the plan's "adopt plan defaults" decision mandates using the xylem schema so calibration work done in one repo transfers to the next.
+
+## Schema
+
+Exact header (must match byte-for-byte):
+
+```
+date,invariant_touched,phase_verdict,human_verdict
+```
+
+| Column            | Type   | Written by | Description                                                                              |
+|-------------------|--------|------------|------------------------------------------------------------------------------------------|
+| `date`            | string | skill      | ISO calendar date, `YYYY-MM-DD`, in the committer's local timezone.                       |
+| `invariant_touched` | string | skill    | Short label, e.g. `queue.md I2 (6-of-19 field mutation coverage)`. See naming below.       |
+| `phase_verdict`   | enum   | skill      | `pass` when diff-checker `match=true` AND `confidence_pct>=80`; otherwise `fail`.          |
+| `human_verdict`   | enum   | human      | One of `genuine`, `genuine-planted`, `partial`, `spurious`, or empty (awaiting review).   |
+
+**`invariant_touched` naming convention.** The label must be stable enough that two runs against the same invariant produce grep-comparable strings. Follow the xylem style:
+
+```
+<module-doc>.md <invariant-id> (<short scope descriptor>)
+```
+
+Examples (from the seed fixtures):
+
+```
+queue.md I2 (failed-terminal sampling)
+queue.md I2 (6-of-19 field mutation coverage)
+queue.md I3 (planted — spec claim vs code violation)
+queue.md I6 (linearizability depth)
+queue.md I2 (ReplaceAll privileged-path coverage)
+queue.md I5b (vesselSetsEquivalentIgnoringClock)
+```
+
+If the invariant has no numbered ID, use a dash-cased keyword from the prose. Avoid free-form English — grepability is the point.
+
+**`human_verdict` semantics.**
+
+| Value            | Meaning                                                                                            |
+|------------------|----------------------------------------------------------------------------------------------------|
+| `genuine`        | The phase flagged a real spec-intent mismatch. Counts against FP numerator as 0.                    |
+| `genuine-planted`| Seeded mismatch fixture caught by the pipeline. Also 0 in FP numerator; used for recall tracking.  |
+| `partial`        | Finding was partially correct (right area, wrong framing). Counts as 0.5 in some reports; for the   |
+|                  | kill criterion, treat `partial` as NOT spurious (i.e. the pipeline is still doing useful work).     |
+| `spurious`       | False positive — the phase fired but the spec+test were actually aligned. Counts as 1 in FP numerator. |
+| empty (`""`)     | Awaiting human review. Ignored by the kill-criterion computation (not in numerator or denominator). |
+
+Filling `human_verdict` is a human responsibility — `/intent-check` never writes anything other than an empty cell. A reviewer who disputes the automated verdict updates this column by editing the CSV directly (or through a PR that touches only this file).
+
+## Example rows
+
+```csv
+date,invariant_touched,phase_verdict,human_verdict
+2026-04-23,queue.md I2 (failed-terminal sampling),fail,genuine
+2026-04-23,queue.md I2 (6-of-19 field mutation coverage),fail,genuine
+2026-04-23,queue.md I3 (planted — spec claim vs code violation),fail,genuine-planted
+2026-04-23,queue.md I6 (linearizability depth),fail,genuine
+2026-04-23,queue.md I2 (ReplaceAll privileged-path coverage),fail,partial
+2026-04-23,queue.md I5b (vesselSetsEquivalentIgnoringClock),fail,spurious
+2026-04-24,runner.md R1 (graceful-shutdown idempotence),pass,
+```
+
+The last row shows an append from the skill — `phase_verdict=pass`, `human_verdict` empty (no reviewer has classified it yet).
+
+## Append logic
+
+Claude runs these steps in order:
+
+1. **Check existence.** `test -f .assurance/intent-check-fp-tracker.csv`. If missing, create the directory if needed (`mkdir -p .assurance`) and write the exact header line followed by a newline.
+2. **Read existing rows.** Load the CSV into memory (for the kill-criterion check in Step 0 of the skill).
+3. **Validate header.** If the header does not match byte-for-byte, refuse to append and tell the user — the schema has drifted and merging rows could lose data. Point at this doc.
+4. **Format the new row.** Use standard RFC 4180 CSV quoting. If `invariant_touched` contains a comma, double-quote the whole field and escape embedded quotes as `""`.
+5. **Append.** Open in append mode; write the new row followed by a newline. Do not rewrite the whole file (avoids a race with concurrent runs, however rare in practice).
+6. **Confirm.** Re-read the tail of the file and show the user the appended row.
+
+Never mutate existing rows. If the user wants to correct an earlier `human_verdict`, they edit the CSV by hand.
+
+## 30% kill-criterion computation
+
+The kill criterion says: if the rolling false-positive rate over the last 14 days of entries exceeds 30%, Layer 5 is not earning its cost and the pipeline must not keep gating commits.
+
+**Pseudocode:**
+
+```python
+from datetime import date, timedelta
+
+def kill_criterion_fp_rate(rows: list[dict], today: date) -> tuple[float, int]:
+    """
+    Returns (fp_rate, window_size).
+    Rows with empty human_verdict are ignored.
+    Rows with human_verdict=='partial' count as NOT spurious.
+    """
+    cutoff = today - timedelta(days=14)
+    window = [
+        r for r in rows
+        if date.fromisoformat(r["date"]) >= cutoff
+        and r["human_verdict"].strip() != ""
+    ]
+    if not window:
+        return (float("nan"), 0)  # unknown
+    spurious = sum(1 for r in window if r["human_verdict"].strip() == "spurious")
+    return (spurious / len(window), len(window))
+```
+
+Skill behaviour against this number:
+
+| `window_size` | `fp_rate`       | Skill action                                                                              |
+|---------------|-----------------|-------------------------------------------------------------------------------------------|
+| 0             | N/A             | Proceed with a warning; note the tracker is empty and no kill-criterion signal is available. |
+| 1–2           | any             | Proceed with a warning; sample too small to trust.                                         |
+| >= 3          | <= 30%          | Proceed silently.                                                                         |
+| >= 3          | > 30%           | **Refuse to run.** Emit the kill-criterion message from Step 0 of the skill.              |
+
+Why 30%: the threshold is inherited from xylem `07-intent-check-phase.md` acceptance criteria and confirmed in `15-intent-check-calibration.md`. A pipeline that cries wolf more than ~1 time in 3 erodes trust faster than the spec-intent drift it was meant to catch.
+
+Why 14 days: matches the xylem "2 weeks of live operation" acceptance criterion. Short enough that a recent prompt regression trips the kill quickly; long enough that a single bad day doesn't overreact.
+
+Why ignore empty `human_verdict`: the reviewer hasn't ruled yet. Counting empty cells either way biases the rate. The cost is that a repo with zero human review will see `window_size=0` forever — that is the correct signal (no evidence either way).
+
+## Recommended review cadence
+
+- **Daily (when active):** reviewer triages the previous day's empty rows.
+- **Weekly:** scan for trends — is any invariant generating only spurious flags? If so, the prose is probably ambiguous; consider amending it via `/protected-surface-amend` rather than re-labelling flags.
+- **Before any prompt change:** snapshot the tracker so the FP-rate impact of the prompt change is measurable.
+
+## Interoperability with xylem
+
+If you run `/intent-check` in a repo that already inherits a xylem-shaped tracker, the rows are directly concatenatable — the columns, types, and enum values are identical. This is the primary benefit of parity.

--- a/crosscheck/skills/intent-check/references/round-trip-prompt.md
+++ b/crosscheck/skills/intent-check/references/round-trip-prompt.md
@@ -1,0 +1,190 @@
+# Round-trip informalization: the two verbatim prompts
+
+This document contains the two prompt templates used by `/intent-check`. They are intentionally verbatim and intentionally strict — the calibration work in `/Users/harry.nicholls/repos/xylem/docs/assurance/next/15-intent-check-calibration.md` identified both as load-bearing fixes for the FP rate (rationale blindness, carve-out blindness, contradictory-output models).
+
+Do not soften either prompt without updating the skill's verification checklist and re-running the kill-criterion math on the rolling window.
+
+## Prompt 1: Back-translator (BLIND to invariant prose)
+
+**Inputs:** `{code}`, `{test}`. **Not** the invariant prose — passing it voids the round-trip.
+
+```
+You are a code reviewer describing what a piece of code and its covering test
+actually guarantee, in plain English. You have NOT been shown any specification
+or intent prose. You must describe only what the code + test enforce, not what
+they were meant to enforce.
+
+Output TWO sections, both mandatory, in this exact order.
+
+### Section 1: Behavioural guarantees
+
+Write a single plain-text paragraph describing the behavioural guarantees the
+code and test together enforce. Be concrete — name state transitions, quantified
+ranges, preserved fields, and what is checked vs. what is merely set up.
+
+### Section 2: Design rationale comments
+
+List every comment block of 3+ lines AND every single-line comment whose text
+contains any of these rationale markers (case-insensitive):
+
+  because, since, artefact, artifact, workaround, zeroed, intentional,
+  skipping, ignore, on purpose, deliberately, known, caveat
+
+For each, output:
+  <file:line-range>
+  > <the comment body, verbatim, preserving internal line breaks>
+
+If no such comments exist, output exactly:
+  None.
+
+Do NOT summarise rationale comments. Quote them verbatim. The diff-checker
+treats Section 2 as authoritative evidence when a gap is apparent; if you
+paraphrase, you destroy that evidence.
+
+---
+
+CODE:
+{code}
+
+---
+
+TEST:
+{test}
+```
+
+### Why Section 2 is mandatory
+
+Calibration finding FP #6 (xylem session 2026-04-23): a test at
+`queue_invariants_prop_test.go:452-457` carried a 6-line rationale explaining
+that clock values were zeroed because of wall-clock drift between runs. The
+earlier single-paragraph back-translator described the *behaviour* accurately
+("ignores clock values") but did not surface the *rationale*. The diff-checker
+then compared the literal behaviour against the spec's literal wording and
+flagged a substantive gap — a false positive.
+
+Forcing Section 2 to list rationale comments verbatim, with file+line anchors,
+makes the rationale first-class evidence rather than an optional summary.
+
+## Prompt 2: Diff-checker (sees both original intent + back-translation)
+
+**Inputs:** `{invariant_prose}`, `{back_translation}` (both sections from Prompt 1).
+
+```
+You are evaluating whether a back-translation of a code+test pair matches the
+original invariant prose. Your job is to decide if any apparent gap is
+substantive, non-substantive, or the artefact of a scope carve-out.
+
+You MUST complete Step 1 before rendering any verdict. Steps are ordered
+because forcing visible intermediate output is more reliable than instructing
+you to "consider" something.
+
+## Step 1: Scan for scope carve-outs
+
+Search the invariant prose for these scope markers (case-insensitive):
+
+  "Not covered", "caller-responsibility", "precondition", "aspirational",
+  "known violation", "privileged", "exempt", "out of scope", "does not apply"
+
+List every carve-out you find:
+  - Quote the clause verbatim.
+  - State what it exempts from the guarantee.
+
+If none found, write exactly: "No carve-outs found."
+
+Also read Section 2 of the back-translation (design rationale comments). Any
+apparent gap that is explained by a rationale comment is NOT substantive.
+
+## Scope modifier taxonomy (apply to each carve-out you find)
+
+| Marker                                         | Meaning                                                                                          |
+|------------------------------------------------|--------------------------------------------------------------------------------------------------|
+| "caller-responsibility" / "precondition"       | The guarantee is conditional. A test that does not exercise the violation case is NOT a gap.     |
+| "Not covered" / "out of scope" / "exempt"      | Explicitly excluded. Any difference in this area is non-substantive by definition.               |
+| "aspirational"                                 | Future-direction note, not a current guarantee. Never flag as a gap.                             |
+| "known violation"                              | Acknowledged divergence. Non-substantive.                                                        |
+| "privileged"                                   | Restricted code-path. Only the privileged path needs to satisfy the invariant.                   |
+
+## Step 2: Evaluate each apparent gap
+
+For each behavioural difference between the invariant prose and the
+back-translation, apply the taxonomy from Step 1. A gap is substantive only
+if NONE of the carve-outs or rationale comments apply to it.
+
+## Step 3: Emit the verdict
+
+Output a single JSON object with exactly these keys:
+
+{
+  "match": true | false,
+  "mismatch_reason": "<string, >= 20 chars when match=false, empty when match=true>",
+  "mismatch_category": one of:
+      "spec_scope_mismatch",   // gap falls within a carve-out; non-substantive
+      "weaker_guarantee",      // test proves strictly less than spec claims
+      "missing_property",      // a specific property is untested
+      "missing_coverage",      // a subset of inputs/states is uncovered
+      "rationale_explains",    // in-source comment explains the divergence
+      "carve_out_applies",     // scope modifier excludes this area
+      "clean_match"            // no gap found
+  ,
+  "confidence_pct": 0-100,
+  "confidence_basis": one of:
+      "carve-out-found",       // scope modifier applied
+      "rationale-found",       // in-source justification comment found
+      "rationale-absent",      // no justification; gap is literal
+      "spec-ambiguous",        // spec prose unclear
+      "code-ambiguous"         // code unclear; verdict uncertain
+}
+
+`confidence_pct` is your confidence that your VERDICT is correct — not your
+confidence that the code is correct. 0 = you are guessing; 100 = you are
+certain.
+
+Do not emit prose outside the JSON object.
+
+---
+
+INVARIANT PROSE:
+{invariant_prose}
+
+---
+
+BACK-TRANSLATION (both sections from the blind back-translator):
+{back_translation}
+```
+
+### Why Step 1 is mandatory (not merely recommended)
+
+Calibration: the diff-checker has been observed to capture the spec's main
+claim but silently ignore conditional scope modifiers when rendering a verdict.
+This is a latent failure mode that hides behind partially-correct findings.
+Forcing a *visible* Step 1 output — quoted clauses, classified by taxonomy —
+means the model cannot silently skip the scan.
+
+## Semantic validation (applied by Claude after parsing, not part of the prompt)
+
+After unmarshaling the diff-checker's JSON, the skill applies two defensive
+rules:
+
+1. `match == true` AND `mismatch_reason` non-empty → contradictory output.
+   Flip to `match=false, confidence_pct=40, confidence_basis="spec-ambiguous",
+   mismatch_category="missing_property"`. Fail-closed interpretation is safer
+   than trusting either half of the contradiction.
+2. `match == false` AND `len(strip(mismatch_reason)) < 20` → reject as
+   truncation. Ask the user to re-run.
+
+These rules live in the skill, not the prompt, so they catch model
+contradictions even if the prompt is tampered with.
+
+## Placeholder expansion order (exact)
+
+| Placeholder         | Source                                                      |
+|---------------------|-------------------------------------------------------------|
+| `{code}`            | Staged code diff relevant to the invariant (scoped, not whole PR) |
+| `{test}`            | Covering property test body, including surrounding rationale comments |
+| `{invariant_prose}` | The relevant invariant section from `docs/invariants/<module>.md` |
+| `{back_translation}`| Section 1 + Section 2 from Prompt 1, verbatim               |
+
+Claude must substitute these placeholders literally, without paraphrasing,
+truncating, or re-formatting the inputs. If a file is too large to fit in the
+context window, scope it down rather than summarising it — a summary by the
+same LLM that runs the pipeline is contamination.


### PR DESCRIPTION
## Summary

- Adds `/intent-check` skill to the crosscheck plugin — portable Layer 5 round-trip informalization for (invariant prose, covering test, code diff) triples.
- Two-LLM pipeline: blind back-translator (sees only code + test, emits behavioural guarantees + verbatim rationale comments) feeding a diff-checker (mandatory carve-out scan before verdict).
- Ships the skill (`SKILL.md`) plus three reference docs under `references/`: the verbatim two-prompt template with Phase-1 calibration fixes, the FP-tracker CSV schema (xylem-parity) with append logic and the 30% kill-criterion math, and the JSON attestation schema with the companion pre-commit hook pseudocode.

Unit #8 of the assurance-hierarchy batch plan at `/Users/harry.nicholls/.claude/plans/temporal-orbiting-turing.md`.

## Test plan

- [x] Frontmatter lint — `name:`, `description:`, `argument-hint:` all present.
- [x] Structure lint — `## Description`, `## Instructions`, `## Arguments`, `Verification Checklist` all present; every references file has 7–16 headings and non-trivial content.
- [x] Cross-reference check — every `references/` path mentioned in SKILL.md resolves to a real file.
- [x] Schema consistency — `mismatch_category` + `confidence_basis` enums match across SKILL.md, round-trip-prompt.md, and attestation-schema.md.
- [ ] Invoke-smoke — not runnable from this worker environment (plugin source tree rather than installed cache; no way to spawn a Claude Code session from within the worker). Recommend a human reviewer types `/intent-check` in a repo with `docs/invariants/` + staged diff to confirm first-turn behaviour aligns with Step 1.

## Scope guardrails honoured

- Only touched files under `crosscheck/skills/intent-check/`.
- Did not edit `byfuglien.md`, `README.md`, `plugin.json`, or anything under `mcp-server/`.
- Skill is methodology markdown, not code — no binary ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)