### PR TITLE
feat(crosscheck): add /acceptance-oracle-draft skill

### DIFF
--- a/crosscheck/skills/acceptance-oracle-draft/SKILL.md
+++ b/crosscheck/skills/acceptance-oracle-draft/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: acceptance-oracle-draft
+description: >-
+  Scope the top-N user-observable flows for a repo and emit mechanically-verifiable
+  acceptance-scenario skeletons (YAML/JSON) plus a runner-script stub. Does NOT run
+  the scenarios — that's CI's job. Enforces a strict mechanical-verification-only
+  rule: subjective criteria ("UX feels good") must be quantified or rejected.
+  Layer 5 proxy for user-perspective / empirical assurance — measures whether the
+  spec was the right spec. Triggers: "acceptance oracle", "draft scenarios",
+  "user-observable flows", "acceptance scenarios", "scenario skeletons".
+argument-hint: "[optional: target surface — cli | http | daemon | github | ui, or path]"
+---
+
+# /acceptance-oracle-draft — User-Perspective Scenario Skeletons
+
+## Description
+
+Layer 5 proxy in the assurance hierarchy — **user-perspective / empirical assurance**. Scopes the top-N user-observable flows for a repo and emits mechanically-verifiable scenario skeletons the user can commit, extend, and wire into CI.
+
+This skill is a methodology doc and scaffold generator. It does **not** execute scenarios; that is the CI job's responsibility. The skill's sole deliverables are: (a) scenario YAML/JSON files, (b) a runner-script stub, (c) a placeholder CI workflow step, and (d) an explicit list of flows that were **rejected** because they could not be mechanically verified.
+
+**CRUCIAL RULE — mechanical verification only.** Every scenario's `then` assertion must be programmatically checkable: exit codes, regex matches, JSON schema validation, HTTP status + body schema, measurable latency thresholds, file existence/content hashes. Subjective criteria ("UX feels good", "response is readable", "user is satisfied") must either be quantified (e.g., "CLI startup < 300 ms measured via `hyperfine`", "response body matches schema `responses/ok.schema.json`") or rejected and reported out-of-scope. The oracle cannot proxy user-perspective assurance if its signals are themselves subjective.
+
+See `references/scenario-schema.md` for the full schema, runner-script pseudocode, and worked rewrites of subjective criteria into mechanical ones.
+
+## Instructions
+
+You are drafting an external acceptance oracle for the user's repo. The oracle sits outside the coding-agent's write loop (scenarios are authored by humans or LLM-drafted then human-approved) and measures user-observable behaviour. Your job is to scope the flows, draft skeletons, and be ruthless about mechanical verifiability.
+
+### Step 1: Identify User-Observable Surfaces
+
+Before proposing any scenario, enumerate the surfaces the repo exposes to external observers. Candidate categories:
+
+- **CLI commands** — binaries users run directly. Signals: exit code, stdout, stderr, side-effect files.
+- **Public HTTP/gRPC API endpoints** — request → response. Signals: status code, response body schema, headers, latency.
+- **Daemon / background behaviours** — long-running processes. Signals: log lines matching a pattern within a time budget, health-check endpoint status, emitted events on a queue.
+- **GitHub integration flows** — webhook handlers, CI bots, PR-comment posters. Signals: emitted comment text matching regex, labels applied, status check posted.
+- **UI interactions** — if the repo ships a UI, only the *programmatically-observable* parts count (DOM assertions via Playwright/Selenium, accessibility-tree shape, network calls emitted). Pure-visual assertions are rejected.
+
+Detect surfaces automatically where possible (look for `cmd/`, `cli/`, `main.go`, `openapi.yaml`, `routes/`, `.github/workflows/`, `packages/*/src`), then ask the user:
+
+> Which surfaces should I include? I detected: `<list>`. Confirm or add others. For each selected surface, the default top-N is 10 (range 3–15).
+
+Do not proceed to Step 2 until the user has confirmed the surface list and N.
+
+### Step 2: Elicit Top-N Flows per Surface
+
+For each selected surface, drive flow elicitation with these three questions (ask them explicitly; don't paraphrase):
+
+1. **"What happens if a new user runs this for the first time?"** — captures happy-path and first-run invariants (config not present, auth not set, etc.).
+2. **"What happens on error X?"** — enumerate at least two error modes per surface (missing input, malformed input, missing dependency, network failure, auth failure, permission denied).
+3. **"What's the observable success signal?"** — forces the user to name the mechanical signal *before* the scenario is drafted. If they can't name one, the flow is a candidate for rejection in Step 7.
+
+Collect flows as a flat list `[(surface, flow-name, expected-signal, priority)]`. Priority values: `P0` (blocking regression — must pass for release), `P1` (important), `P2` (nice to have). Keep `P0` flows to roughly 1/3 of the top-N so the gate remains actionable when something fails.
+
+### Step 3: Draft Scenario Skeletons
+
+For each flow, draft a scenario following the schema in `references/scenario-schema.md`. The schema requires:
+
+- `name` — stable kebab-case identifier.
+- `surface` — one of the Step 1 categories.
+- `priority` — `P0` / `P1` / `P2`.
+- `given` — preconditions (fixture files, env vars, repo state). Must be reproducible on a clean CI runner.
+- `when` — the action (command line, HTTP request, daemon signal). Must be expressible as a shell invocation or a structured request.
+- `then` — the **mechanically-verifiable** assertion. Must compile to a deterministic predicate. See schema doc for the allowed assertion types (`exit_code`, `stdout_matches`, `http_status`, `json_schema`, `latency_under_ms`, `file_exists`, `file_sha256`, `log_line_within_seconds`).
+- `timeout` — wall-clock limit in seconds. Defaults: CLI 30s, HTTP 10s, daemon 60s.
+
+Each scenario goes in its own file at `acceptance/scenarios/<flow-name>.yaml` in the target repo (propose this path; the user may override). YAML is the primary format; include a JSON equivalent in the reference doc for teams that prefer JSON.
+
+### Step 4: Emit the Runner-Script Stub
+
+Generate `acceptance/run.sh` (or `acceptance/run.<lang>` if the repo has an obvious test runner — pytest, go test, jest). Default is language-neutral bash + jq walking the scenario files and dispatching per-surface. See `references/scenario-schema.md` §Runner for the pseudocode.
+
+The stub must:
+
+1. Enumerate `acceptance/scenarios/*.yaml`.
+2. For each scenario: run `when`, capture stdout/stderr/exit code/timing, evaluate `then` mechanically, report pass/fail with the scenario name and the reason.
+3. Exit non-zero if any `P0` scenario failed. `P1`/`P2` failures emit warnings but don't fail the run (configurable via `--strict`).
+4. Emit a single JUnit-style XML or JSON report at `acceptance/report.xml` or `.json` so CI can surface it.
+
+Do not implement anything the runner can't support — if the schema permits assertions the stub doesn't handle, annotate `# TODO: implement <assertion>` in the stub and document it in the PR description the user will use.
+
+### Step 5: Emit a Placeholder CI Workflow Step
+
+Generate a `.github/workflows/acceptance-oracle.yml` snippet (or equivalent for GitLab / Circle if the repo uses them) that:
+
+- Triggers on PRs touching the user-observable source paths you identified in Step 1 (emit the `paths:` filter explicitly; do not use a wildcard).
+- Runs the oracle runner from Step 4.
+- Uploads the report as an artifact.
+- Fails the check on any `P0` failure.
+
+This is a placeholder — the user may already have a CI system with established conventions. Mark it clearly as `# GENERATED BY /acceptance-oracle-draft — adjust to match your CI conventions`.
+
+### Step 6: Propose a Storage Boundary
+
+Recommend that scenarios live **outside** the coding-agent's write scope to preserve the external-oracle property (see `docs/research/assurance-hierarchy.md` §External Acceptance Oracle — scenarios authored by humans, not by the agent under test). Two options:
+
+- **Sibling directory** — e.g. `../<repo-name>-acceptance/` outside the main working tree.
+- **Separate repo** — e.g. `<org>/<repo-name>-acceptance`, referenced as a git submodule or CI checkout.
+
+For the initial draft, scenarios can live at `acceptance/scenarios/` inside the repo so the user can review the pattern, but the skill **must** flag this and recommend the user move them before wiring the oracle into the merge gate. Document the move in the PR description.
+
+### Step 7: Explicitly Enumerate Rejected Flows
+
+This is non-negotiable. At the end of the output, print a section titled `## Rejected Flows (out of scope for this oracle)` listing every flow proposed during Step 2 that could not be mechanically verified, with the reason. Example:
+
+```
+## Rejected Flows (out of scope for this oracle)
+
+| Flow | Why rejected | Suggested alternative |
+|---|---|---|
+| "CLI help output is readable" | Subjective; no measurable signal. | Replace with "help output contains sections `USAGE`, `COMMANDS`, `FLAGS` (regex check)" — see §mechanical-rewrites in scenario-schema.md. |
+| "Dashboard looks nice" | Pure-visual; no programmatic observable. | Out of scope. Consider manual QA checklist or screenshot-diff tool. |
+| "Error message is helpful" | Subjective. | Replace with "error message contains the failing path and a `hint:` prefix (regex check)". |
+```
+
+This section is the **coverage boundary** of the oracle. The user needs it to know what the oracle is **not** catching.
+
+### Step 8: Verification Checklist
+
+Present this checklist alongside the emitted files:
+
+```
+## Verification Checklist
+
+After this draft, verify:
+- [ ] Every scenario's `then` assertion is programmatically checkable — no "user is satisfied", no "looks right", no "feels fast".
+- [ ] At least 3 scenarios are ready to go live within 4 weeks (kill criterion: fewer than 3 = top-N was wrong, re-scope).
+- [ ] 10 scenarios are active within 12 weeks.
+- [ ] A deliberately introduced regression in a covered flow triggers the gate locally (`./acceptance/run.sh` returns non-zero).
+- [ ] Scenarios are stored outside the coding-agent's write scope before the oracle becomes a merge gate (sibling dir or separate repo).
+- [ ] Rejected flows are listed explicitly so the coverage boundary is visible.
+- [ ] The CI workflow snippet targets the correct `paths:` filter (user-observable source paths only).
+- [ ] False-positive rate is monitored — if >30% of failures are scenario brittleness rather than real regressions, simplify the scenarios.
+```
+
+Fill in the bracketed items with specifics from the current draft.
+
+## Arguments
+
+Optional: target surface to scope (`cli`, `http`, `daemon`, `github`, `ui`) or a path hint. If omitted, the skill asks the user to choose in Step 1.
+
+Examples:
+- `/acceptance-oracle-draft` — full interactive scoping across all detected surfaces.
+- `/acceptance-oracle-draft cli` — scope only the CLI surface.
+- `/acceptance-oracle-draft cli/` — scope the CLI surface rooted at `cli/`.
+
+## References
+
+- `references/scenario-schema.md` — YAML/JSON scenario schema, runner-script pseudocode, and worked rewrites of subjective criteria into mechanical ones.

--- a/crosscheck/skills/acceptance-oracle-draft/SKILL.md
+++ b/crosscheck/skills/acceptance-oracle-draft/SKILL.md
@@ -93,7 +93,7 @@ This is a placeholder — the user may already have a CI system with established
 
 ### Step 6: Propose a Storage Boundary
 
-Recommend that scenarios live **outside** the coding-agent's write scope to preserve the external-oracle property (see `docs/research/assurance-hierarchy.md` §External Acceptance Oracle — scenarios authored by humans, not by the agent under test). Two options:
+Recommend that scenarios live **outside** the coding-agent's write scope to preserve the external-oracle property (the external-oracle principle: scenarios are authored by humans, not by the agent under test — see the assurance-hierarchy notes if your repo has them checked in under `docs/research/`). Two options:
 
 - **Sibling directory** — e.g. `../<repo-name>-acceptance/` outside the main working tree.
 - **Separate repo** — e.g. `<org>/<repo-name>-acceptance`, referenced as a git submodule or CI checkout.

--- a/crosscheck/skills/acceptance-oracle-draft/references/scenario-schema.md
+++ b/crosscheck/skills/acceptance-oracle-draft/references/scenario-schema.md
@@ -1,0 +1,234 @@
+# Acceptance-Oracle Scenario Schema
+
+This document defines the YAML/JSON schema for scenarios emitted by `/acceptance-oracle-draft`, plus a runner-script stub and the mechanical-verification-only rule with worked rewrites.
+
+## Schema (YAML, primary format)
+
+```yaml
+# acceptance/scenarios/<flow-name>.yaml
+name: <kebab-case-identifier>         # required; unique across the scenario directory
+surface: cli | http | daemon | github | ui   # required
+priority: P0 | P1 | P2                # required; P0 failures block merge
+timeout_seconds: <int>                # required; wall-clock budget
+given:                                # preconditions (reproducible on a clean CI runner)
+  env:                                # optional map of env vars to set
+    KEY: value
+  files:                              # optional list of fixture files to materialise
+    - path: fixtures/input.json
+      content_sha256: <hash>          # or inline `content: |` for small fixtures
+  repo_state:                         # optional git-state preconditions
+    clean: true
+when:                                 # the action; exactly one of `cmd`, `http`, `signal`
+  cmd:                                # shell invocation for CLI scenarios
+    argv: ["mytool", "build", "--out", "dist"]
+    stdin: ""                         # optional
+  # OR
+  http:                               # HTTP request for API scenarios
+    method: POST
+    url: http://localhost:8080/api/v1/jobs
+    headers:
+      Content-Type: application/json
+    body_file: fixtures/input.json    # or `body: |` inline
+  # OR
+  signal:                             # daemon/background signal
+    action: restart | health_check | emit_event
+    target: <daemon-name>
+then:                                 # list of mechanically-verifiable assertions
+  - exit_code: 0                      # CLI only
+  - stdout_matches: '^build complete in \d+ms$'   # regex, line-anchored by default
+  - stderr_empty: true
+  - http_status: 201                  # HTTP only
+  - json_schema: schemas/job.schema.json           # path to a JSON Schema file
+  - latency_under_ms: 300
+  - file_exists: dist/bundle.js
+  - file_sha256:
+      path: dist/bundle.js
+      hash: <expected-sha256>
+  - log_line_within_seconds:
+      pattern: 'daemon ready on port \d+'
+      seconds: 5
+```
+
+### JSON equivalent
+
+The same schema expressed as JSON, for teams that prefer it:
+
+```json
+{
+  "name": "cli-build-happy-path",
+  "surface": "cli",
+  "priority": "P0",
+  "timeout_seconds": 30,
+  "given": {
+    "env": {"MYTOOL_CONFIG": "fixtures/config.yaml"},
+    "files": [{"path": "fixtures/input.json", "content_sha256": "abc123..."}]
+  },
+  "when": {
+    "cmd": {"argv": ["mytool", "build", "--out", "dist"]}
+  },
+  "then": [
+    {"exit_code": 0},
+    {"stdout_matches": "^build complete in \\d+ms$"},
+    {"file_exists": "dist/bundle.js"}
+  ]
+}
+```
+
+### Allowed assertion types (mechanical only)
+
+| Assertion | Applies to | Signal |
+|---|---|---|
+| `exit_code: <int>` | cli | Process exit code matches. |
+| `stdout_matches: <regex>` | cli | At least one stdout line matches. |
+| `stdout_equals: <string>` | cli | Full stdout equals string. |
+| `stderr_empty: true` | cli | stderr has zero bytes. |
+| `http_status: <int>` | http | Response status equals. |
+| `json_schema: <path>` | http, cli (JSON output) | Response/stdout parses and validates against the JSON Schema. |
+| `header_matches` | http | Response header matches regex. |
+| `latency_under_ms: <int>` | cli, http | Wall-clock under threshold. |
+| `file_exists: <path>` | any | Path exists after `when`. |
+| `file_sha256: {path, hash}` | any | File content SHA-256 matches. |
+| `log_line_within_seconds: {pattern, seconds}` | daemon | A log line matching pattern appears within N seconds. |
+
+If you need an assertion that isn't on this list, either add it here (and implement in the runner) or reject the scenario. **Do not** invent ad-hoc subjective assertions.
+
+## Full example 1 — CLI scenario
+
+```yaml
+# acceptance/scenarios/cli-build-happy-path.yaml
+name: cli-build-happy-path
+surface: cli
+priority: P0
+timeout_seconds: 30
+given:
+  env:
+    MYTOOL_CONFIG: fixtures/config.yaml
+  files:
+    - path: fixtures/config.yaml
+      content: |
+        target: es2022
+        outdir: dist
+when:
+  cmd:
+    argv: ["mytool", "build", "src/index.ts"]
+then:
+  - exit_code: 0
+  - stdout_matches: '^build complete in \d+ms$'
+  - file_exists: dist/index.js
+  - latency_under_ms: 5000
+```
+
+## Full example 2 — HTTP API scenario
+
+```yaml
+# acceptance/scenarios/api-create-job.yaml
+name: api-create-job
+surface: http
+priority: P0
+timeout_seconds: 10
+given:
+  env:
+    API_BASE_URL: http://localhost:8080
+when:
+  http:
+    method: POST
+    url: http://localhost:8080/api/v1/jobs
+    headers:
+      Content-Type: application/json
+      Authorization: Bearer test-token
+    body: |
+      {"name": "smoke-job", "payload": {"x": 1}}
+then:
+  - http_status: 201
+  - json_schema: schemas/job-created.schema.json
+  - header_matches:
+      name: Location
+      pattern: '^/api/v1/jobs/[a-f0-9-]{36}$'
+  - latency_under_ms: 500
+```
+
+## Runner-script stub (bash + jq, ~30 lines)
+
+Emit this as `acceptance/run.sh` in the target repo. Pseudocode covers the common paths; extend per assertion.
+
+```bash
+#!/usr/bin/env bash
+# GENERATED BY /acceptance-oracle-draft — extend per project needs.
+set -uo pipefail   # intentionally NOT -e: scenario failures shouldn't abort the run.
+
+SCENARIO_DIR="${SCENARIO_DIR:-acceptance/scenarios}"
+REPORT="${REPORT:-acceptance/report.json}"
+STRICT="${STRICT:-false}"   # true → P1/P2 failures also exit non-zero
+
+pass=0 fail=0
+results="[]"
+
+for f in "$SCENARIO_DIR"/*.yaml; do
+  name=$(yq '.name' "$f")
+  prio=$(yq '.priority' "$f")
+  timeout_s=$(yq '.timeout_seconds' "$f")
+  surface=$(yq '.surface' "$f")
+  verdict=skip reason="unsupported surface: $surface"
+
+  if [[ "$surface" == cli ]]; then
+    # Read argv as a JSON array and exec it directly (no shell re-parsing).
+    mapfile -t argv < <(yq -o=json '.when.cmd.argv[]' "$f" | jq -r '.')
+    expected_rc=$(yq '.then[] | select(has("exit_code")) | .exit_code' "$f")
+    timeout "$timeout_s" "${argv[@]}" >/tmp/oracle.out 2>&1
+    rc=$?
+    if [[ -n "$expected_rc" && "$rc" -ne "$expected_rc" ]]; then
+      verdict=fail reason="exit_code=$rc expected=$expected_rc"
+    else
+      verdict=pass reason=""
+      # TODO: evaluate stdout_matches, file_exists, latency_under_ms, etc.
+    fi
+  fi
+  # TODO: implement surface=http (curl; http_status, json_schema, header_matches).
+  # TODO: implement surface=daemon (log_line_within_seconds, health_check).
+
+  if [[ "$verdict" == pass ]]; then pass=$((pass + 1)); else fail=$((fail + 1)); fi
+  results=$(jq --arg n "$name" --arg p "$prio" --arg v "$verdict" --arg r "$reason" \
+    '. + [{name: $n, priority: $p, verdict: $v, reason: $r}]' <<<"$results")
+  echo "[$verdict] $name ($prio) $reason"
+done
+
+jq --argjson p "$pass" --argjson f "$fail" '{summary: {pass: $p, fail: $f}, scenarios: .}' \
+  <<<"$results" > "$REPORT"
+
+# Fail the run if any P0 failed, or any failure in strict mode.
+if jq -e '.[] | select(.verdict=="fail" and .priority=="P0")' <<<"$results" >/dev/null; then exit 1; fi
+if [[ "$STRICT" == "true" && "$fail" -gt 0 ]]; then exit 1; fi
+```
+
+Dependencies: `yq` (mikefarah, YAML→JSON), `jq`, `curl` (for HTTP scenarios), `timeout`. Document these in the PR description.
+
+## Mechanical-verification-only rule
+
+Every scenario's `then` must compile to a deterministic predicate on observable process/file/network state. If you catch yourself writing a `then` that requires a human to judge it, stop and rewrite — or reject.
+
+### Worked rewrites (subjective → mechanical)
+
+**Example 1.**
+
+- Rejected: *"CLI startup feels fast."*
+- Rewritten: `latency_under_ms: 300` on `mytool --help`, measured via `hyperfine --warmup 3 mytool --help` on CI baseline hardware. Document the baseline hardware in the PR so threshold drift isn't misread as regression.
+
+**Example 2.**
+
+- Rejected: *"Help output is readable."*
+- Rewritten: three mechanical checks — `stdout_matches: '^USAGE:'`, `stdout_matches: '^COMMANDS:'`, `stdout_matches: '^FLAGS:'`. Readability as a whole stays subjective, but section-presence is a sharp signal for the regression you actually care about (someone deleted a help section).
+
+**Example 3.**
+
+- Rejected: *"Error message is helpful when config is missing."*
+- Rewritten: two mechanical checks — `exit_code: 2` (conventional for usage errors) and `stderr_matches: 'config file .+ not found \(set MYTOOL_CONFIG or pass --config\)'`. The regex enforces that the error names the missing path and tells the user how to fix it. "Helpful" as a vibe is discarded; "contains path + hint" is what actually matters.
+
+### When to reject rather than rewrite
+
+If none of the mechanical assertion types in the table above can express what you're trying to check, reject the flow. Candidates:
+
+- Pure-visual correctness ("the chart looks right") — no programmatic observable.
+- "Feels polished" — no measurable quantity.
+- "Conforms to brand guidelines" — requires a human comparator.
+
+Put rejected flows in the `## Rejected Flows` section of the skill output (see `SKILL.md` Step 7) so the coverage boundary is explicit. Do not quietly drop them; the user needs to know what the oracle isn't catching.

--- a/crosscheck/skills/acceptance-oracle-draft/references/scenario-schema.md
+++ b/crosscheck/skills/acceptance-oracle-draft/references/scenario-schema.md
@@ -37,6 +37,7 @@ then:                                 # list of mechanically-verifiable assertio
   - exit_code: 0                      # CLI only
   - stdout_matches: '^build complete in \d+ms$'   # regex, line-anchored by default
   - stderr_empty: true
+  - stderr_matches: 'config file .+ not found'    # regex over stderr lines
   - http_status: 201                  # HTTP only
   - json_schema: schemas/job.schema.json           # path to a JSON Schema file
   - latency_under_ms: 300
@@ -82,6 +83,7 @@ The same schema expressed as JSON, for teams that prefer it:
 | `stdout_matches: <regex>` | cli | At least one stdout line matches. |
 | `stdout_equals: <string>` | cli | Full stdout equals string. |
 | `stderr_empty: true` | cli | stderr has zero bytes. |
+| `stderr_matches: <regex>` | cli | At least one stderr line matches. |
 | `http_status: <int>` | http | Response status equals. |
 | `json_schema: <path>` | http, cli (JSON output) | Response/stdout parses and validates against the JSON Schema. |
 | `header_matches` | http | Response header matches regex. |
@@ -168,7 +170,7 @@ for f in "$SCENARIO_DIR"/*.yaml; do
   prio=$(yq '.priority' "$f")
   timeout_s=$(yq '.timeout_seconds' "$f")
   surface=$(yq '.surface' "$f")
-  verdict=skip reason="unsupported surface: $surface"
+  verdict=skip; reason="unsupported surface: $surface"
 
   if [[ "$surface" == cli ]]; then
     # Read argv as a JSON array and exec it directly (no shell re-parsing).
@@ -177,16 +179,20 @@ for f in "$SCENARIO_DIR"/*.yaml; do
     timeout "$timeout_s" "${argv[@]}" >/tmp/oracle.out 2>&1
     rc=$?
     if [[ -n "$expected_rc" && "$rc" -ne "$expected_rc" ]]; then
-      verdict=fail reason="exit_code=$rc expected=$expected_rc"
+      verdict=fail; reason="exit_code=$rc expected=$expected_rc"
     else
-      verdict=pass reason=""
+      verdict=pass; reason=""
       # TODO: evaluate stdout_matches, file_exists, latency_under_ms, etc.
     fi
   fi
   # TODO: implement surface=http (curl; http_status, json_schema, header_matches).
   # TODO: implement surface=daemon (log_line_within_seconds, health_check).
 
-  if [[ "$verdict" == pass ]]; then pass=$((pass + 1)); else fail=$((fail + 1)); fi
+  case "$verdict" in
+    pass) pass=$((pass + 1)) ;;
+    fail) fail=$((fail + 1)) ;;
+    skip) : ;;  # skipped scenarios don't count toward pass/fail
+  esac
   results=$(jq --arg n "$name" --arg p "$prio" --arg v "$verdict" --arg r "$reason" \
     '. + [{name: $n, priority: $p, verdict: $v, reason: $r}]' <<<"$results")
   echo "[$verdict] $name ($prio) $reason"


### PR DESCRIPTION
## Summary

- Adds `/acceptance-oracle-draft` — Layer 5 proxy of the assurance hierarchy. Scopes top-N user-observable flows for a repo and emits mechanically-verifiable scenario skeletons (YAML/JSON) plus a runner-script stub and placeholder CI workflow step.
- Enforces the mechanical-verification-only rule: subjective criteria must be quantified (`hyperfine` latency, schema validation, etc.) or explicitly rejected and reported as out-of-scope for this oracle.
- Ships two files under `crosscheck/skills/acceptance-oracle-draft/`: `SKILL.md` (methodology) and `references/scenario-schema.md` (YAML + JSON schema, full CLI example, full HTTP example, bash runner stub, three subjective-to-mechanical rewrites).

Unit 10 of the 10-unit assurance-hierarchy batch (see plan at `/Users/harry.nicholls/.claude/plans/temporal-orbiting-turing.md`).

## Test plan

- [x] Frontmatter lint — `name`, `description`, `argument-hint` all present.
- [x] Structure lint — `## Description`, `## Instructions`, `## Arguments`, `Verification Checklist` all present.
- [x] `git status` clean — only the two new files in the skill directory committed.
- [ ] Invoke-smoke deferred to human reviewer (plugin loads from installed cache, not the source tree — source additions aren't discoverable until plugin reinstall/republish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)