### PR TITLE
refactor(crosscheck): generalize intent-check skill from xylem-specific phrasing

### DIFF
--- a/crosscheck/skills/intent-check/SKILL.md
+++ b/crosscheck/skills/intent-check/SKILL.md
@@ -17,7 +17,7 @@ argument-hint: "[optional: invariant doc path] [optional: covering test path]"
 
 Operationalise Layer 5 (spec-intent alignment) of the assurance hierarchy as a portable, repo-agnostic Claude Code skill. The input is a triple — an **invariant prose description**, a **covering property test**, and the **code diff** the user wants to ship. The output is a structured verdict (match / mismatch + confidence + reason), an appended row in a per-repo false-positive tracker CSV, and a content-hashed JSON attestation that a companion pre-commit hook can check without invoking an LLM.
 
-The skill is a portable analog of Midspiral's `claimcheck` and xylem's `xylem-intent-check` binary. It is structurally adversarial by construction: the back-translator is **blind to the original intent prose**, so it cannot tautologically restate it, and the diff-checker is forced to scan for carve-outs and rationale comments before rendering a verdict. These two prompt-level guardrails are the Phase-1 calibration fixes that drive the false-positive rate below the 30% kill criterion.
+The skill is a portable analog of Midspiral's `claimcheck` and an internal Go-binary precursor. It is structurally adversarial by construction: the back-translator is **blind to the original intent prose**, so it cannot tautologically restate it, and the diff-checker is forced to scan for carve-outs and rationale comments before rendering a verdict. These two prompt-level guardrails are the Phase-1 calibration fixes that drive the false-positive rate below the 30% kill criterion.
 
 This is a methodology skill. It does not ship a binary — Claude drives the pipeline itself, reading files, invoking the two prompts in the required order, writing the tracker row and the attestation, and running the kill-criterion math before committing. The companion pre-commit hook (described in `references/attestation-schema.md`) is fast and LLM-free: it only checks hashes and verdicts.
 
@@ -113,11 +113,11 @@ date,invariant_touched,phase_verdict,human_verdict
 ```
 
 - `date` — today in `YYYY-MM-DD`.
-- `invariant_touched` — a short label identifying the invariant under test, e.g. `queue.md I2 (6-of-19 field mutation coverage)`. Match the style of the xylem tracker (see `references/fp-tracker-schema.md`).
+- `invariant_touched` — a short label identifying the invariant under test, e.g. `queue.md I2 (6-of-19 field mutation coverage)`. Match the style described in `references/fp-tracker-schema.md`.
 - `phase_verdict` — `pass` if `match == true` **AND** `confidence_pct >= 80`; `fail` otherwise. This must match the `verdict` written to the attestation in Step 6 — low-confidence matches are tracked as `fail` so the kill criterion picks up prompt weakness, and the attestation hook refuses the commit.
 - `human_verdict` — leave **empty** at skill-run time. A human reviewer fills this in later as `genuine`, `genuine-planted`, `partial`, or `spurious`. The kill-criterion math ignores empty cells (see `references/fp-tracker-schema.md` for the append logic and the rolling-window computation).
 
-The schema matches xylem's CSV verbatim — this is the plan's "adopt plan defaults" decision. Do not add columns; do not rename columns.
+The schema is fixed — do not add columns and do not rename columns. Stability across repos is what makes the rows directly concatenatable for cross-repo calibration analysis.
 
 ### Step 6: Write the Attestation
 
@@ -183,7 +183,7 @@ If `match == false`, tell the user exactly what the back-translator perceived vs
 - [ ] Back-translation contains both Section 1 (behavioural guarantees) and Section 2 (rationale comments, verbatim with file:line)
 - [ ] Diff-checker performed the mandatory Step 1 carve-out scan before rendering a verdict
 - [ ] Diff-checker output passes semantic validation (no contradictory match/reason, reason >= 20 chars when non-empty)
-- [ ] FP-tracker row appended with the exact xylem schema (date, invariant_touched, phase_verdict, human_verdict)
+- [ ] FP-tracker row appended with the exact schema (date, invariant_touched, phase_verdict, human_verdict)
 - [ ] Attestation emitted with sorted protected_files, SHA-256 content_hash, verdict, RFC3339 checked_at, and pipeline_output
 - [ ] Pre-commit hook behaviour described (not installed) so the user can wire it up via their hook config
 - [ ] User given the remediation path if verdict is fail (fix code / fix test / amend invariant with /protected-surface-amend)

--- a/crosscheck/skills/intent-check/references/attestation-schema.md
+++ b/crosscheck/skills/intent-check/references/attestation-schema.md
@@ -2,7 +2,7 @@
 
 `/intent-check` writes `.assurance/intent-check-attestation.json` on every run. The attestation is the deterministic, LLM-free record that a companion pre-commit hook uses to decide whether a commit touching protected-surface files is allowed.
 
-The pattern is lifted from xylem (`/Users/harry.nicholls/repos/xylem/docs/assurance/next/07-intent-check-phase.md`, lines 34–58) and generalised so any repo can adopt it without a Go binary.
+The pattern is lifted from the upstream design (see `../../../docs/research/assurance-hierarchy.md`) and generalised so any repo can adopt it without a Go binary.
 
 ## Why an attestation (not just a CI job)
 

--- a/crosscheck/skills/intent-check/references/fp-tracker-schema.md
+++ b/crosscheck/skills/intent-check/references/fp-tracker-schema.md
@@ -2,7 +2,7 @@
 
 `/intent-check` appends one row to `.assurance/intent-check-fp-tracker.csv` per pipeline run. The tracker is the only persistent record of round-trip verdicts and is the input to the 30% kill criterion that decides whether Layer 5 stays online.
 
-The schema matches the xylem tracker at `/Users/harry.nicholls/repos/xylem/docs/assurance/next/07-fp-tracker.csv` verbatim. Parity is deliberate — the plan's "adopt plan defaults" decision mandates using the xylem schema so calibration work done in one repo transfers to the next.
+The schema is inherited verbatim from the upstream design referenced in `../../../docs/research/assurance-hierarchy.md`. Parity is deliberate — keeping the columns, types, and enum values fixed means calibration work done in one repo transfers cleanly to the next.
 
 ## Schema
 
@@ -19,7 +19,7 @@ date,invariant_touched,phase_verdict,human_verdict
 | `phase_verdict`   | enum   | skill      | `pass` when diff-checker `match=true` AND `confidence_pct>=80`; otherwise `fail`.          |
 | `human_verdict`   | enum   | human      | One of `genuine`, `genuine-planted`, `partial`, `spurious`, or empty (awaiting review).   |
 
-**`invariant_touched` naming convention.** The label must be stable enough that two runs against the same invariant produce grep-comparable strings. Follow the xylem style:
+**`invariant_touched` naming convention.** The label must be stable enough that two runs against the same invariant produce grep-comparable strings. Follow this style:
 
 ```
 <module-doc>.md <invariant-id> (<short scope descriptor>)
@@ -115,9 +115,9 @@ Skill behaviour against this number:
 | >= 3          | <= 30%          | Proceed silently.                                                                         |
 | >= 3          | > 30%           | **Refuse to run.** Emit the kill-criterion message from Step 0 of the skill.              |
 
-Why 30%: the threshold is inherited from xylem `07-intent-check-phase.md` acceptance criteria and confirmed in `15-intent-check-calibration.md`. A pipeline that cries wolf more than ~1 time in 3 erodes trust faster than the spec-intent drift it was meant to catch.
+Why 30%: the threshold is inherited from the upstream design (see `../../../docs/research/assurance-hierarchy.md` for the rationale). A pipeline that cries wolf more than ~1 time in 3 erodes trust faster than the spec-intent drift it was meant to catch.
 
-Why 14 days: matches the xylem "2 weeks of live operation" acceptance criterion. Short enough that a recent prompt regression trips the kill quickly; long enough that a single bad day doesn't overreact.
+Why 14 days: matches the "2 weeks of live operation" acceptance criterion from the same source. Short enough that a recent prompt regression trips the kill quickly; long enough that a single bad day doesn't overreact.
 
 Why ignore empty `human_verdict`: the reviewer hasn't ruled yet. Counting empty cells either way biases the rate. The cost is that a repo with zero human review will see `window_size=0` forever — that is the correct signal (no evidence either way).
 
@@ -127,6 +127,6 @@ Why ignore empty `human_verdict`: the reviewer hasn't ruled yet. Counting empty 
 - **Weekly:** scan for trends — is any invariant generating only spurious flags? If so, the prose is probably ambiguous; consider amending it via `/protected-surface-amend` rather than re-labelling flags.
 - **Before any prompt change:** snapshot the tracker so the FP-rate impact of the prompt change is measurable.
 
-## Interoperability with xylem
+## Schema portability
 
-If you run `/intent-check` in a repo that already inherits a xylem-shaped tracker, the rows are directly concatenatable — the columns, types, and enum values are identical. This is the primary benefit of parity.
+Because the columns, types, and enum values are fixed, rows from different repos are directly concatenatable into a single dataset. This is the primary benefit of holding the schema steady — calibration analyses (FP-rate trends, prompt-regression detection, per-invariant noise profiling) can pool data across repos without bespoke ETL.

--- a/crosscheck/skills/intent-check/references/round-trip-prompt.md
+++ b/crosscheck/skills/intent-check/references/round-trip-prompt.md
@@ -54,16 +54,9 @@ TEST:
 
 ### Why Section 2 is mandatory
 
-Calibration finding FP #6 (calibration session 2026-04-23): a test at
-`queue_invariants_prop_test.go:452-457` carried a 6-line rationale explaining
-that clock values were zeroed because of wall-clock drift between runs. The
-earlier single-paragraph back-translator described the *behaviour* accurately
-("ignores clock values") but did not surface the *rationale*. The diff-checker
-then compared the literal behaviour against the spec's literal wording and
-flagged a substantive gap — a false positive.
+Calibration finding FP #6 (calibration session 2026-04-23): a test at `queue_invariants_prop_test.go:452-457` carried a 6-line rationale explaining that clock values were zeroed because of wall-clock drift between runs. The earlier single-paragraph back-translator described the *behaviour* accurately ("ignores clock values") but did not surface the *rationale*. The diff-checker then compared the literal behaviour against the spec's literal wording and flagged a substantive gap — a false positive.
 
-Forcing Section 2 to list rationale comments verbatim, with file+line anchors,
-makes the rationale first-class evidence rather than an optional summary.
+Forcing Section 2 to list rationale comments verbatim, with file+line anchors, makes the rationale first-class evidence rather than an optional summary.
 
 ## Prompt 2: Diff-checker (sees both original intent + back-translation)
 
@@ -154,26 +147,16 @@ BACK-TRANSLATION (both sections from the blind back-translator):
 
 ### Why Step 1 is mandatory (not merely recommended)
 
-Calibration: the diff-checker has been observed to capture the spec's main
-claim but silently ignore conditional scope modifiers when rendering a verdict.
-This is a latent failure mode that hides behind partially-correct findings.
-Forcing a *visible* Step 1 output — quoted clauses, classified by taxonomy —
-means the model cannot silently skip the scan.
+Calibration: the diff-checker has been observed to capture the spec's main claim but silently ignore conditional scope modifiers when rendering a verdict. This is a latent failure mode that hides behind partially-correct findings. Forcing a *visible* Step 1 output — quoted clauses, classified by taxonomy — means the model cannot silently skip the scan.
 
 ## Semantic validation (applied by Claude after parsing, not part of the prompt)
 
-After unmarshaling the diff-checker's JSON, the skill applies two defensive
-rules:
+After unmarshaling the diff-checker's JSON, the skill applies two defensive rules:
 
-1. `match == true` AND `mismatch_reason` non-empty → contradictory output.
-   Flip to `match=false, confidence_pct=40, confidence_basis="spec-ambiguous",
-   mismatch_category="missing_property"`. Fail-closed interpretation is safer
-   than trusting either half of the contradiction.
-2. `match == false` AND `len(strip(mismatch_reason)) < 20` → reject as
-   truncation. Ask the user to re-run.
+1. `match == true` AND `mismatch_reason` non-empty → contradictory output. Flip to `match=false, confidence_pct=40, confidence_basis="spec-ambiguous", mismatch_category="missing_property"`. Fail-closed interpretation is safer than trusting either half of the contradiction.
+2. `match == false` AND `len(strip(mismatch_reason)) < 20` → reject as truncation. Ask the user to re-run.
 
-These rules live in the skill, not the prompt, so they catch model
-contradictions even if the prompt is tampered with.
+These rules live in the skill, not the prompt, so they catch model contradictions even if the prompt is tampered with.
 
 ## Placeholder expansion order (exact)
 
@@ -184,7 +167,4 @@ contradictions even if the prompt is tampered with.
 | `{invariant_prose}` | The relevant invariant section from `docs/invariants/<module>.md` |
 | `{back_translation}`| Section 1 + Section 2 from Prompt 1, verbatim               |
 
-Claude must substitute these placeholders literally, without paraphrasing,
-truncating, or re-formatting the inputs. If a file is too large to fit in the
-context window, scope it down rather than summarising it — a summary by the
-same LLM that runs the pipeline is contamination.
+Claude must substitute these placeholders literally, without paraphrasing, truncating, or re-formatting the inputs. If a file is too large to fit in the context window, scope it down rather than summarising it — a summary by the same LLM that runs the pipeline is contamination.

--- a/crosscheck/skills/intent-check/references/round-trip-prompt.md
+++ b/crosscheck/skills/intent-check/references/round-trip-prompt.md
@@ -1,6 +1,6 @@
 # Round-trip informalization: the two verbatim prompts
 
-This document contains the two prompt templates used by `/intent-check`. They are intentionally verbatim and intentionally strict — the calibration work in `/Users/harry.nicholls/repos/xylem/docs/assurance/next/15-intent-check-calibration.md` identified both as load-bearing fixes for the FP rate (rationale blindness, carve-out blindness, contradictory-output models).
+This document contains the two prompt templates used by `/intent-check`. They are intentionally verbatim and intentionally strict — upstream calibration work identified both as load-bearing fixes for the FP rate (rationale blindness, carve-out blindness, contradictory-output models).
 
 Do not soften either prompt without updating the skill's verification checklist and re-running the kill-criterion math on the rolling window.
 
@@ -54,7 +54,7 @@ TEST:
 
 ### Why Section 2 is mandatory
 
-Calibration finding FP #6 (xylem session 2026-04-23): a test at
+Calibration finding FP #6 (calibration session 2026-04-23): a test at
 `queue_invariants_prop_test.go:452-457` carried a 6-line rationale explaining
 that clock values were zeroed because of wall-clock drift between runs. The
 earlier single-paragraph back-translator described the *behaviour* accurately


### PR DESCRIPTION
## Summary

One of nine coordinated PRs in a docs refresh that strips internal `xylem` project references from the `crosscheck/` plugin so its skills read as fully repo-agnostic Claude Code artefacts.

This PR (U2) covers the `/intent-check` skill:

- Removes 4 absolute paths under `/Users/harry.nicholls/repos/xylem/...`, replacing them with relative pointers to `docs/research/assurance-hierarchy.md` (where the FP-tracker schema, 30% kill criterion, and 14-day rolling-window rationale now live in generalised form).
- Replaces project-name attributions ("xylem's `xylem-intent-check` binary", "the xylem tracker", "xylem session 2026-04-23") with neutral phrasing ("an internal Go-binary precursor", "the upstream design", "calibration session 2026-04-23").
- Renames the `## Interoperability with xylem` section in `fp-tracker-schema.md` to `## Schema portability`, preserving the underlying rationale (deterministic columns mean rows from different repos concatenate cleanly into a single dataset).

## Files touched

- `crosscheck/skills/intent-check/SKILL.md`
- `crosscheck/skills/intent-check/references/fp-tracker-schema.md`
- `crosscheck/skills/intent-check/references/round-trip-prompt.md`
- `crosscheck/skills/intent-check/references/attestation-schema.md`

## Schema portability note

The CSV schema itself is **unchanged** — `date,invariant_touched,phase_verdict,human_verdict` is the same byte-for-byte header. Rows produced by `/intent-check` in any repo remain directly concatenatable for cross-repo calibration analysis (FP-rate trends, prompt-regression detection, per-invariant noise profiling). Only the prose framing around the schema has been generalised.

The "Midspiral's `claimcheck`" reference is intentionally retained — that is a real external prior-art comparison.

## Test plan

- [x] `grep -i xylem` over the 4 touched files returns zero matches
- [x] Each file read end-to-end — prose flows naturally, no orphan "as described in xylem above" stubs, no broken sentences
- [x] All section headers, code fences, and table structures intact
- [x] Cross-references to `references/*.md` files within the skill are preserved and still resolve
- [x] Relative-path references to `../../../docs/research/assurance-hierarchy.md` are consistent across the four files

🤖 Generated with [Claude Code](https://claude.com/claude-code)