### PR TITLE
docs(crosscheck): add assurance hierarchy + literature review research docs

### DIFF
--- a/crosscheck/docs/research/assurance-hierarchy.md
+++ b/crosscheck/docs/research/assurance-hierarchy.md
@@ -1,0 +1,98 @@
+# A Six-Layer Assurance Hierarchy for AI-Assisted Software Development
+
+## Scope
+
+This hierarchy addresses the question: **given a specification, can we be confident the implementation is correct?** It explicitly excludes whether the specification solves the right problem — that is a product discovery concern, not an engineering assurance concern.
+
+## The Hierarchy
+
+### Layer 1: Formally Verified Pure, Functional Code
+
+Business logic and core algorithms are written in a formally verifiable language such as Dafny, which compiles to target languages including JavaScript and TypeScript. The formal verification toolchain (Dafny's verifier, or Lean 4 via tools like Axiom or Harmonic's Aristotle) provides mathematical proof that the code satisfies its specification for all possible inputs — not just tested inputs.
+
+This is deterministic assurance: the proof either passes or it doesn't.
+
+### Layer 2: Compilation Correctness
+
+Formal verification proves properties of source code, but the deployed system runs compiled output. If the compiler has a bug, the emitted code may not preserve the properties proven in the source language. This layer provides assurance that the compilation or transpilation step preserves verified properties.
+
+Approaches include verified compilation (e.g., CompCert for C), translation validation (verifying each specific compilation output against its source), or proof-carrying code where proofs travel with the compiled artifact.
+
+Without this layer, a formally verified Dafny program and its compiled JavaScript output are connected only by trust in the compiler — an unverified link in an otherwise verified chain.
+
+### Layer 3: Contract Graph Verification
+
+Individual verified units must compose correctly. The contract graph verifier checks interface contracts at integration boundaries — between verified units and between verified code and third-party libraries. Critically, this verification operates end-to-end across subgraphs, not just at pairwise boundaries.
+
+This distinction matters because two units can each satisfy their boundary contracts while producing emergent behavior that neither unit's specification anticipated — ordering dependencies, resource contention, or feedback loops that only manifest in the full assembly. End-to-end subgraph verification catches these composition failures.
+
+This layer targets the approximately 75% of code surface area that sits at integration boundaries, which resists formal proof of individual units and is where the majority of production bugs originate.
+
+### Layer 4: Implementation–Specification Alignment
+
+Layers 1–3 prove that code satisfies a specification. This layer asks: does the specification actually describe the implementation's behavior? Tools like Midspiral's lemmafit integrate Dafny verification into the development workflow, where code that cannot be proven correct against the specification does not compile.
+
+This is still deterministic — the verifier accepts or rejects.
+
+### Layer 5: Specification–Intent Alignment
+
+A verified proof guarantees the code is correct relative to a specification, but does the specification capture what was actually intended? This is the gap between "verified" and "intended."
+
+Midspiral's claimcheck addresses this via round-trip informalization: translate the formal specification back into plain English without seeing the original requirement, then compare the back-translation against the original intent. In testing, this caught both planted errors and unexpected gaps — for example, a requirement stating "adding a ballot can't decrease a tally" where the lemma merely proved counts are non-negative, a tautology masquerading as a monotonicity guarantee.
+
+This layer is probabilistic. Claimcheck reports approximately 96.3% accuracy using structural separation (two models, with the informalizer blind to the original requirement), though this is acknowledged as a development benchmark rather than a formal evaluation.
+
+### Layer 6: Specification Completeness
+
+Even if every specified property is correctly implemented and aligned with intent, the specification itself may be incomplete — it may fail to enumerate properties that matter. Traditional user stories test the happy path and some error cases, getting nowhere near the exhaustive coverage that formal verification provides.
+
+The concept of formally verified user stories addresses this: rather than writing a handful of test cases from a user story, an LLM systematically enumerates candidate formal properties — invariants, pre/post conditions, boundary behaviors, commutativity, monotonicity, conservation laws. A human reviews the property list, each property is formally verified, and claimcheck validates intent alignment.
+
+This layer is best-effort. There is no theorem that can prove a specification is complete — the question "have I missed any important properties?" is inherently a human judgment call. However, adversarial property discovery — where one agent proposes properties and another agent tries to find scenarios the property set doesn't cover — could make this search significantly more structured than the status quo.
+
+## Two Chains, One Gradient
+
+The hierarchy contains two distinct chains with different failure modes and verification methods:
+
+**The Implementation Chain (Layers 1–3):** Is the code correct and do the pieces fit together? This chain is deterministically verifiable via formal proofs and contract checks.
+
+**The Specification Chain (Layers 4–6):** Does the spec match the code, the intent, and the full problem surface? This chain degrades from deterministic (Layer 4) to probabilistic (Layer 5, ~96%) to best-effort (Layer 6).
+
+Residual risk concentrates at the top of the specification chain — Layer 6 — which is where the research opportunity lies.
+
+## Applying the hierarchy to a real codebase
+
+How far each layer reaches in practice depends on the host language, the maturity of its verification tooling, and the shape of the system being built. The notes below describe what tends to be reachable in mainstream ecosystems (Go, Python, TypeScript, Rust); the crosscheck plugin's skills are referenced where they directly support a layer.
+
+**Layer 1 (formally verified pure code).** Reachable today for sequential, pure logic via Dafny, with extraction to Python or Go. The crosscheck plugin's `/spec-iterate`, `/generate-verified`, and `/extract-code` skills cover this path. Concurrent and effectful code falls outside the verifiable surface and must be handled at higher layers.
+
+**Layer 2 (compilation correctness).** Aspirational outside niche stacks. CompCert exists for C; nothing equivalent exists for Go, Python, TypeScript, or Rust. In mainstream ecosystems, the production compiler is part of the trusted computing base.
+
+**Layer 3 (contract graph verification).** Pairwise interface contracts are reachable in some languages (e.g., Gobra for Go, refinement types in Liquid Haskell, contract decorators in Python). End-to-end subgraph verification across a real service remains a research frontier — viable for distributed protocols (Veil on Lean) but not yet a turnkey practice for application code.
+
+**Layer 4 (implementation-spec alignment).** Reachable wherever Layer 1 is reachable. Enforced via CI gates that run `dafny_verify` on touched specs and via the `/invariant-coverage-scaffold` skill, which generates a bidirectional invariant-to-test coverage gate so every documented invariant has a covering test and every "Invariant <ID>" comment points at a real doc.
+
+**Layer 5 (spec-intent alignment).** Reachable as a probabilistic check using LLM round-trip informalization. The `/intent-check` skill implements this for invariant-prose / covering-test / code-diff triples, with a false-positive tracker and a 30% kill criterion. Expect ~96% accuracy on curated benchmarks; real-PR accuracy will only be known once it has run on protected-surface diffs for some time.
+
+**Layer 6 (spec completeness).** Best-effort. The `/spec-adversary` skill probes a module's invariant doc for missing properties, and `/acceptance-oracle-draft` generates mechanically-verifiable user-perspective scenarios as an empirical complement to invariant coverage. No theorem proves spec completeness; both are iterative practices, not gates.
+
+## Supporting Workflow Elements
+
+Two additional practices sit alongside the hierarchy rather than within it:
+
+**External Acceptance Oracle.** Deterministic verification steps written from the perspective of a user, exercising the feature to determine if the user story is satisfied. These exist outside the repository so the coding agent cannot write code to pass them, and are written before development starts to force upfront intent specification. Requirements must be mechanically verifiable — subjective criteria like "the page feels responsive" must be quantified. The oracle provides empirical, user-perspective assurance that the service works, complementing the exhaustive assurance of formal verification.
+
+**Test Theatre Detection.** Critical review of automated tests to eliminate tests that look productive but verify nothing meaningful. This runs after the implementation has stabilized — not as a sequential pipeline step during development, but as a quality gate once there is confidence the code has stopped changing.
+
+## References
+
+- Axiom. AXLE - Axiom Lean Engine. https://axle.axiommath.ai/
+- Axiom. https://axiommath.ai/
+- Harmonic. Aristotle API. https://aristotle.harmonic.fun/
+- Harmonic. "Aristotle: IMO-level Automated Theorem Proving." arXiv, March 2026. https://arxiv.org/html/2510.01346v1
+- Midspiral. https://midspiral.com/
+- Midspiral. "lemmafit: Make agents prove that their code is correct." GitHub. https://github.com/midspiral/lemmafit
+- Midspiral. "claimcheck: Narrowing the Gap between Proof and Intent." https://midspiral.com/blog/claimcheck-narrowing-the-gap-between-proof-and-intent/
+- Midspiral. "From Intent to Proof: Dafny Verification for Web Apps." https://midspiral.com/blog/from-intent-to-proof-dafny-verification-for-web-apps/
+- Kleppmann, M. "Prediction: AI will make formal verification go mainstream." December 2025. https://martin.kleppmann.com/2025/12/08/ai-formal-verification.html
+- de Moura, L. "When AI Writes the World's Software, Who Verifies It?" February 2026. https://leodemoura.github.io/blog/2026/02/28/when-ai-writes-the-worlds-software.html

--- a/crosscheck/docs/research/literature-review.md
+++ b/crosscheck/docs/research/literature-review.md
@@ -1,0 +1,93 @@
+# Brief Literature Review: Formal Verification Hierarchies and AI-Assisted Code Assurance
+
+## Purpose
+
+This review was conducted to assess whether the six-layer assurance hierarchy described in the companion report ("A Six-Layer Assurance Hierarchy for AI-Assisted Software Development") has precedent in existing literature. The review is preliminary — conducted over the course of a single conversation, not a systematic literature search — and should be treated as a starting point for a proper review, not a definitive novelty claim.
+
+## Existing Work
+
+### Guaranteed Safe AI (Dalrymple et al., 2024)
+
+The closest structural analog identified. This paper proposes a verification hierarchy spanning from no guarantees (Level 0) through increasingly sophisticated empirical testing methods (Levels 1–5), probabilistic inference with convergence guarantees (Levels 6–8), to formal proofs establishing definitive safety bounds (Levels 9–10). The framework is organized around three core components: a world model (mathematical description of how the AI system affects the outside world), a safety specification (mathematical description of acceptable effects), and a verifier (auditable proof certificate).
+
+The paper also notes that AI capabilities could accelerate creation of good safety specifications — for example, AI systems could suggest new specifications, critique proposed ones, or generate examples of cases where two candidate specifications differ.
+
+**Relevance:** This is the most important prior work to engage with. The confidence gradient (deterministic → probabilistic → best-effort) and the structural decomposition into distinct verification concerns are shared features. The key divergences are: (1) GS AI targets AI system safety broadly, not developer workflows specifically; (2) it does not distinguish an implementation chain from a specification chain; (3) it does not address compilation correctness, contract graph verification at integration boundaries, or the spec-intent alignment problem as distinct layers.
+
+### Kleppmann (2025)
+
+Martin Kleppmann's blog post argues that formal verification is about to become mainstream due to three converging factors: formal verification is becoming vastly cheaper, AI-generated code needs formal verification so human review can be skipped, and the precision of formal verification counteracts the imprecise nature of LLMs. He identifies the specification problem clearly: as verification becomes automated, the challenge moves to correctly defining the specification — knowing that the properties proven are the right ones.
+
+**Relevance:** Kleppmann names the spec completeness problem but does not propose a layered hierarchy or structured approach to addressing it. The observation that "it doesn't matter if [LLMs] hallucinate nonsense, because the proof checker will reject any invalid proof" is foundational context for why LLM-assisted formal verification is viable.
+
+### Midspiral: lemmafit and claimcheck
+
+Midspiral builds open-source tools for what they call "the correctness layer for AI-generated software." Two tools are directly relevant:
+
+**lemmafit** integrates Dafny formal verification into the Claude Code development workflow. Business logic is written in Dafny, mathematically verified, then auto-compiled to TypeScript for use in React applications. A verification daemon watches .dfy files, runs `dafny verify`, and on success compiles to JavaScript/TypeScript. Code that cannot be proven correct does not compile.
+
+**claimcheck** addresses the gap between "verified" and "intended" using round-trip informalization. The technique sends a Dafny lemma to one LLM (blind to the original requirement) to describe what it guarantees in plain English, then sends both the original requirement and the back-translation to a second LLM to assess semantic match. In testing against an election tally system, claimcheck caught both a planted error (a tautology masquerading as a monotonicity guarantee) and an unexpected gap (a lemma proving one specific reordering rather than arbitrary permutation). Structural separation (two different models, informalizer blind to the requirement) outperformed single-model approaches by 10 points. Reported accuracy is 96.3%, acknowledged as a development benchmark rather than a formal evaluation.
+
+**Relevance:** Midspiral addresses spec-intent alignment (Layer 5 of the hierarchy) as a specific tool, and frames it as "one layer in an ongoing attempt to map natural language requirements to formal guarantees." They do not propose a broader hierarchy. Their blog post "From Intent to Proof" notes that a more transparent workflow would surface generated domain obligations back to the user in human-readable form before proof generation begins, allowing iteration on intent before committing to proof search — which aligns with the specification chain concept but is not formalized as such.
+
+### Axiom
+
+Axiom trains AI systems to generate formally verified outputs in Lean. The system uses deterministic proof verifiers to detect incorrect outputs, providing mathematical certainty that code functions return the correct answer for every input. Axiom also verifies that code does not introduce hidden vulnerabilities. The company raised $200M in Series A funding (March 2026) at a $1.6B valuation, and has released AXLE (Axiom Lean Engine) as a public API providing proof verification and manipulation primitives.
+
+Axiom's approach involves a "verified data flywheel" — orders of magnitude more formally verified data than all previously available human-produced sources — which feeds back into training. Because this data is checked by deterministic proof verifiers, it avoids the data pollution and model collapse problems associated with unverified AI-generated training data.
+
+**Relevance:** Axiom provides the tooling substrate for Layer 1 (formally verified code) via Lean. Their focus is on making formal verification cheap and automated, not on defining an assurance hierarchy. The recursive self-improvement loop (verified data improving the model that generates verified data) is relevant infrastructure but does not address the specification chain.
+
+### Harmonic: Aristotle
+
+Harmonic's Aristotle system combines formal verification with informal reasoning, achieving gold-medal-equivalent performance on the 2025 International Mathematical Olympiad with formally verified solutions in Lean 4. The system can autonomously prove and formalize for up to 24 hours without human intervention and leads ProofBench rankings. Harmonic's roadmap includes expansion from mathematics into software verification, targeting safety-critical industries.
+
+The system works by requiring models to produce reasoning as code in Lean 4, which is then checked by an algorithmic process independent of the AI. Every solution is verified down to foundational axioms using the Lean 4 proof assistant.
+
+**Relevance:** Like Axiom, Aristotle provides tooling for Layer 1. Harmonic's stated roadmap into software verification and code correctness suggests these tools will become directly applicable to the assurance hierarchy's implementation chain. The key architectural insight — that the verifier is outside the loop and does not negotiate — aligns with the hierarchy's principle that each layer provides independent assurance.
+
+### de Moura (2026)
+
+Leonardo de Moura's blog post surveys the Lean ecosystem and argues that verification will be a decisive advantage in software development. He notes that AI agents are already building their own proof strategies on top of the Lean platform, and highlights Veil, a distributed protocol verifier built on Lean that combines model checking with full formal proof. Veil generates concrete counterexamples when properties fail and full formal proofs when they hold. During verification of the Rabia consensus protocol, the Veil team discovered an inconsistency in a prior formal verification that had gone undetected across two separate tools.
+
+De Moura also raises the specification problem as not purely technical: specifications for medical devices, voting systems, or AI safety monitors encode values, not just logic. He suggests AI can bridge the accessibility gap by explaining specifications in plain language.
+
+**Relevance:** The Veil work is directly relevant to Layer 3 (contract graph verification), specifically for distributed systems where composition verification is hardest. The observation about specifications encoding values connects to the boundary the hierarchy draws between Layer 6 (spec completeness) and the explicitly excluded "right solution for the right problem" domain.
+
+### Skomarovsky (2026)
+
+A practitioner-oriented post proposing five independent structural dimensions that determine whether AI-generated code is amenable to formal verification. The framework classifies code artifacts by tractability rather than defining layers of assurance.
+
+**Relevance:** Complementary but structurally different. Skomarovsky's framework answers "can we verify this?" while the assurance hierarchy answers "given that we can, what layers of confidence do we have?"
+
+## Assessment of Novelty
+
+The individual concepts in the hierarchy exist separately in the literature:
+
+- **Confidence gradients** in verification are present in the GS AI paper
+- **Spec-intent alignment** is addressed by Midspiral's claimcheck
+- **Spec completeness** as the limiting problem is named by Kleppmann and Midspiral
+- **Contract verification at composition boundaries** is well-studied, particularly in hardware verification and distributed systems (Veil)
+- **Compilation correctness** is a known concern (CompCert, translation validation)
+- **Formally verified code via LLM-assisted tools** is actively developed by Axiom, Harmonic, and Midspiral
+
+What was not found in this review is a single framework assembling these into a unified hierarchy with the specific structure proposed: the split into an implementation chain (Layers 1–3, deterministic) and a specification chain (Layers 4–6, degrading from deterministic through probabilistic to best-effort), with explicit identification of where residual risk concentrates.
+
+**Caveat:** This review was conducted in a single conversation session, not as a systematic literature search. "Not found" is weaker than "does not exist." A proper literature review — particularly engaging deeply with the GS AI paper, the formal methods in AI-generated code space, and the DO-178C / safety-critical systems literature — would be required before making any novelty claims in publication.
+
+## References
+
+- Dalrymple, D. et al. "Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems." 2024. https://arxiv.org/html/2405.06624v1
+- Kleppmann, M. "Prediction: AI will make formal verification go mainstream." December 2025. https://martin.kleppmann.com/2025/12/08/ai-formal-verification.html
+- Midspiral. "claimcheck: Narrowing the Gap between Proof and Intent." https://midspiral.com/blog/claimcheck-narrowing-the-gap-between-proof-and-intent/
+- Midspiral. "From Intent to Proof: Dafny Verification for Web Apps." https://midspiral.com/blog/from-intent-to-proof-dafny-verification-for-web-apps/
+- Midspiral. "lemmafit: Make agents prove that their code is correct." GitHub. https://github.com/midspiral/lemmafit
+- Axiom. https://axiommath.ai/
+- Axiom. AXLE - Axiom Lean Engine. https://axle.axiommath.ai/
+- SiliconANGLE. "Verifiable AI startup Axiom raises $200M to prove AI-generated code is safe to use." March 2026. https://siliconangle.com/2026/03/12/verifiable-ai-startup-axiom-raises-200m-prove-ai-generated-code-safe-use/
+- Menlo Ventures. "AI Will Write All the Code. Mathematics Will Prove It Works." March 2026. https://menlovc.com/perspective/ai-will-write-all-the-code-mathematics-will-prove-it-works/
+- Harmonic. "Aristotle: IMO-level Automated Theorem Proving." arXiv, March 2026. https://arxiv.org/html/2510.01346v1
+- Harmonic. News. https://harmonic.fun/news
+- de Moura, L. "When AI Writes the World's Software, Who Verifies It?" February 2026. https://leodemoura.github.io/blog/2026/02/28/when-ai-writes-the-worlds-software.html
+- Lean FRO. https://lean-lang.org/fro/about/
+- Skomarovsky. "Your AI Just Wrote 500 Lines of Code. Can You Prove Any of It Works?" April 2026. https://skomarovsky.github.io/verification/verification_framework.html


### PR DESCRIPTION
## Summary

Adds two new research documents under `crosscheck/docs/research/` that ground the recently-landed Layer 4-6 assurance suite:

- **`assurance-hierarchy.md`** — the six-layer hierarchy (implementation chain L1-3 deterministic, specification chain L4-6 degrading from deterministic through probabilistic to best-effort), plus a section on how far each layer reaches in mainstream ecosystems (Go, Python, TypeScript, Rust) and which crosscheck skills support each layer (`/spec-iterate`, `/generate-verified`, `/extract-code`, `/invariant-coverage-scaffold`, `/intent-check`, `/spec-adversary`, `/acceptance-oracle-draft`).
- **`literature-review.md`** — brief preliminary survey of prior art (Guaranteed Safe AI, Kleppmann, Midspiral lemmafit/claimcheck, Axiom, Harmonic Aristotle, de Moura, Skomarovsky) with an explicit novelty caveat.

Both documents are generalised from internal-to-another-repo originals so the framing reads as a portable Claude Code plugin rather than work tied to any single host codebase. Zero references to the source codebase remain.

This is **PR 1 of 9** surfacing the assurance suite (9 new skills + new orchestrator agent `hellebuyck`) inside the crosscheck plugin's docs tree.

## Test plan

- [x] `grep -i xylem crosscheck/docs/research/assurance-hierarchy.md` returns empty
- [x] `grep -i xylem crosscheck/docs/research/literature-review.md` returns empty
- [x] `grep -E '^#' crosscheck/docs/research/assurance-hierarchy.md` confirms heading outline intact (Scope, The Hierarchy + 6 layers, Two Chains, Applying the hierarchy to a real codebase, Supporting Workflow Elements, References)
- [x] `literature-review.md` byte-for-byte matches the source (verified via `diff`)
- [x] All seven skill names referenced in the rewritten section exist in `crosscheck/skills/`
- [ ] Reviewer reads both files end-to-end and confirms prose flows cleanly across the rewritten section

🤖 Generated with [Claude Code](https://claude.com/claude-code)