### PR TITLE
refactor(crosscheck): generalize assurance-init and hellebuyck from xylem references

### DIFF
--- a/crosscheck/agents/hellebuyck.md
+++ b/crosscheck/agents/hellebuyck.md
@@ -135,7 +135,7 @@ Every result must pass these quality gates before delivery:
 
 **For spec-chain verification output (`/intent-check`, `/spec-adversary`):**
 - **Structural separation** — `/intent-check` uses two distinct model contexts (back-translator blind to original requirement, diff-checker compares)
-- **FP-tracker appended** — `/intent-check` writes a CSV row matching the xylem schema (`date,invariant_touched,phase_verdict,human_verdict`) and a JSON attestation with `protected_files / content_hash / verdict / checked_at / pipeline_output`
+- **FP-tracker appended** — `/intent-check` writes a CSV row matching the FP-tracker schema documented in `../skills/intent-check/references/fp-tracker-schema.md` (`date,invariant_touched,phase_verdict,human_verdict`) and a JSON attestation with `protected_files / content_hash / verdict / checked_at / pipeline_output`
 - **Signal-to-noise** — `/spec-adversary` proposes ≤3 candidate invariants, each with accept/reject/defer radio formatting; avoid spraying low-value suggestions
 - **Best-effort honesty** — Layer 6 output is explicitly labelled best-effort; no false claim of completeness
 

--- a/crosscheck/skills/assurance-init/SKILL.md
+++ b/crosscheck/skills/assurance-init/SKILL.md
@@ -78,7 +78,7 @@ If the user passed a comma-separated list as `$ARGUMENTS`, use those names and c
 
 ### Step 3: Write `docs/assurance/ROADMAP.md`
 
-Create the file with the following sections (filled with generalised language — strip any crosscheck- or xylem-specific references):
+Create the file with the following sections (filled with generalised language — strip any tool-name-specific references):
 
 1. **Purpose** — one paragraph: "This directory tracks the execution of the 6-layer assurance hierarchy as applied pragmatically to this repository. It exists so the plan survives across long timeframes without depending on conversation context or ephemeral plan files. Each numbered item below has its own standalone doc under `immediate/`, `next/`, `medium-term/`, or `aspirational/`. That doc is the source of truth for scope, acceptance criteria, and kill criteria."
 2. **Strategic Context** — state the long-term goal: "deterministic AI-driven software development": formally verified kernels for critical pure logic, contract graphs for integration boundaries, and spec-intent alignment checks for everything else. Include a "current projection" placeholder table with the six layers and `TODO: fill from /assurance-layer-audit output` in each reach cell.
@@ -327,7 +327,7 @@ After both skills run, `/assurance-status` Phase 1 should pass.
       the real gate)
 - [ ] Summary names the next two skills: `/draft-invariants` then
       `/invariant-coverage-scaffold`
-- [ ] No xylem- or crosscheck-specific references leaked into the generated
+- [ ] No tool-name-specific references leaked into the generated
       files (text should read as repo-agnostic)
 - [ ] Pre-flight overwrite check (Step 1.3) ran and any pre-existing target
       files were either skipped or overwritten per the user's decision — no

--- a/crosscheck/skills/assurance-init/SKILL.md
+++ b/crosscheck/skills/assurance-init/SKILL.md
@@ -254,9 +254,7 @@ line when the property test lands.
 - `docs/assurance/ROADMAP.md` — strategic context.
 ```
 
-The `<!-- aspirational -->` markers indicate invariants that are declared but
-not yet covered by a property test — this keeps the future coverage gate from
-hard-failing on a freshly scaffolded repo.
+The `<!-- aspirational -->` markers indicate invariants that are declared but not yet covered by a property test — this keeps the future coverage gate from hard-failing on a freshly scaffolded repo.
 
 ### Step 7: Emit Pre-commit and CI Stubs (Dual-Track)
 


### PR DESCRIPTION
## Summary

One of 9 PRs in a coordinated docs refresh that removes lingering xylem-codebase references from the crosscheck plugin's Layer 4-6 assurance artefacts. The shipped skills and agents are general-purpose Claude Code components and must read that way.

This PR (slice U5) bundles two small, related edits because each touches only a couple of lines:

- `crosscheck/skills/assurance-init/SKILL.md` — two checklist references to "crosscheck- or xylem-specific references" relaxed to "tool-name-specific references".
- `crosscheck/agents/hellebuyck.md` — the `/intent-check` FP-tracker guideline now cites the in-tree schema doc (`../skills/intent-check/references/fp-tracker-schema.md`) instead of "the xylem schema".

End result: both files contain zero xylem / Xylem mentions. Heading outlines and surrounding prose are unchanged.

The top-level `xylem` plugin in this marketplace is a separate, legitimate plugin and is intentionally left alone.

## Test plan

- [x] `grep -i xylem crosscheck/skills/assurance-init/SKILL.md` returns no matches
- [x] `grep -i xylem crosscheck/agents/hellebuyck.md` returns no matches
- [x] Heading outline (`grep -E '^#'`) unchanged in both files
- [x] Affected paragraphs read end-to-end with prose intact
- [ ] commitlint accepts the `refactor(crosscheck):` prefix on these `SKILL.md` / `agents/*.md` paths (the `docs:` prefix is blocked for these files, which is why this is a `refactor:` commit)

Generated with [Claude Code](https://claude.com/claude-code)