### PR TITLE
feat(crosscheck): threshold framing A4

### DIFF
--- a/crosscheck/README.md
+++ b/crosscheck/README.md
@@ -2,17 +2,23 @@
 
 AI agents write plausible code fast. Plausible isn't the same as correct, and "looks fine" doesn't survive contact with production. Crosscheck gives you six layers of progressively stronger correctness checks, and four of them are shipping today.
 
-Crosscheck checks Claude's code claims with two orchestrator agents — `byfuglien` (implementation) and `hellebuyck` (specification) — coordinating three pillars of assurance. The first pillar is formal verification with Dafny, producing provably correct Python/Go from natural-language specs. The second is semi-formal reasoning, which forces evidence-grounded certificates before any conclusion about a piece of code. The third is a 6-layer assurance hierarchy with governance scaffolding, so claims about correctness keep holding as the code evolves.
+Crosscheck checks Claude's code claims with two orchestrator agents — `byfuglien` (implementation) and `hellebuyck` (specification) — coordinating three pillars of assurance. The first pillar is formal verification with Dafny — code is verified against its spec, then compiled to Python or Go via the Dafny backends. Layer 1 covers the verified core; embedding it correctly in your application is your responsibility, and Layer 2 of the hierarchy (compilation correctness) treats the Dafny-to-Python/Go backend as part of your trusted computing base — see [`./docs/research/assurance-hierarchy.md`](./docs/research/assurance-hierarchy.md). The second pillar is semi-formal reasoning, which forces evidence-grounded certificates before any conclusion about a piece of code. The third is a 6-layer assurance hierarchy with governance scaffolding, so claims about correctness keep holding as the code evolves.
 
 ![03122-ezgif com-optimize](https://github.com/user-attachments/assets/260bd90a-59d1-4d5e-aada-4411d2db397b)
 
-What you can run right now:
-- Layer 1 — proof, not vibes. /spec-iterate → /generate-verified → /extract-code produces Dafny-verified Python or Go. The compiler refuses to emit code that doesn't satisfy its spec. /lightweight-verify adds contracts and property tests where full verification is overkill.
-- Layer 4 — your spec and your code can't drift. /invariant-coverage-scaffold installs a pre-commit + CI gate tying every documented invariant to a covering test. /protected-surface-amend forces a structured governance note on every edit to load-bearing files. /check-regressions re-verifies specs whose source has moved.
-- Layer 5 — your spec actually matches what you meant. /intent-check runs round-trip informalization (~96% accuracy) so AI-drafted invariants get caught when they say something subtly different from the prose. /acceptance-oracle-draft locks user-observable flows into mechanically-verifiable scenarios upfront.
-- Layer 6 — what is your spec still missing? /spec-adversary adversarially probes stable modules for undocumented invariants.
+Why this matters for AI-driven development: the failure mode of an LLM coder isn't bad syntax — it's silent semantic drift, deleted guarantees, and under-specified contracts. Every layer here is a different machine-checkable trap for exactly that.
 
-Why this matters for AI-driven development: the failure mode of an LLM coder isn't bad syntax — it's silent semantic drift, deleted guarantees, and under-specified contracts. Every layer here is a different machine-checkable trap for exactly that. Start with /assurance-layer-audit to see what's reachable in your repo, then /assurance-init to scaffold the governance, and /assurance-status weekly to watch for drift.
+**Recommended order** (the default workflow, evaluations first):
+
+1. `/assurance-layer-audit` — diagnose what's actually reachable in your repo before you commit to any layer.
+2. `/assurance-init` — scaffold the governance skeleton: ROADMAP, protected surfaces, seed invariant docs.
+3. `/acceptance-oracle-draft` — lock the user-observable flows into mechanically-verifiable scenarios. Treat as a user-perspective oracle that sits alongside the hierarchy (the docs file it under "Supporting Workflow Elements" — see [`./docs/research/assurance-hierarchy.md`](./docs/research/assurance-hierarchy.md)). Highest-leverage starting point per the literature on intent formalization (Lahiri 2026; Phoenix-style "evaluations as the codebase").
+4. `/intent-check` and `/invariant-coverage-scaffold` — pin invariant prose to covering tests so the two cannot drift, and run round-trip intent verification on AI-drafted invariants (~96% accuracy on curated benchmarks; real-PR accuracy unmeasured — see [`./docs/research/assurance-hierarchy.md`](./docs/research/assurance-hierarchy.md)).
+5. **Optional, when the code shape supports it:** `/spec-iterate` → `/generate-verified` → `/extract-code` for Dafny-verified cores. Empirical reach for Layer 1 is roughly 22–27% of typical full-stack codebases ([`./docs/research/logic-distribution-analysis.md`](./docs/research/logic-distribution-analysis.md)); reach for your repo will vary. `/lightweight-verify` adds contracts and property tests where full proof is overkill.
+6. `/spec-adversary` once a module has a ratified invariant doc — iterative best-effort probing for undocumented properties; it has its own signal-to-noise kill criteria (see the SKILL).
+7. **Weekly cadence:** `/assurance-status` for drift detection and `/assurance-roadmap-check` to keep ROADMAP item statuses honest.
+
+Layers shipping today (1, 4, 5, 6) plus the orthogonal semi-formal reasoning skills are summarised in the persona table below; full per-skill catalogue at [`./docs/skills.md`](./docs/skills.md).
 
 ## Quickstart
 
@@ -32,21 +38,34 @@ Use the hellebuyck agent to scope this repo's assurance reach
 
 ## The two orchestrator agents
 
-**Byfuglien** (/ˈbʌflɪn/) owns the implementation chain: formal verification with Dafny and semi-formal reasoning over existing code. It covers Layers 1–3 of the assurance hierarchy — code-level correctness, behavioural evidence, and impl-level invariants. Named after Dustin Byfuglien, the crosschecking enforcer: no unsupported claim survives, no unverified code ships.
+**Byfuglien** (/ˈbʌflɪn/) owns the implementation chain: formal verification with Dafny and semi-formal reasoning over existing code. It owns Layer 1 (Dafny formal verification) and the regression-detection slice of Layer 4 (`/check-regressions`). Layers 2–3 are deliberately not addressed — Layer 2 is a trusted-computing-base concern, Layer 3 (contract graph verification) is a research frontier outside niche stacks; see [`./docs/research/assurance-hierarchy.md`](./docs/research/assurance-hierarchy.md). Byfuglien also owns the four semi-formal reasoning skills, which sit outside the layer hierarchy entirely. Named after Dustin Byfuglien, the crosschecking enforcer: no unsupported claim survives, no unverified code ships.
 
 **Hellebuyck** owns the specification chain: Layers 4–6 of the assurance hierarchy (impl–spec alignment, spec–intent alignment, and spec completeness) plus the governance scaffolding that keeps specs honest as code evolves. Named after Connor Hellebuyck, the goalie — the last line of defence when proof runs out and you have to argue that the spec itself was the right one.
+
+The split is principled in shape but **asymmetric in substance** — Byfuglien anchors a single deterministic layer and four orthogonal reasoning skills; Hellebuyck carries three layers (deterministic → probabilistic → best-effort) plus governance. The table below names the skill ownership directly so the asymmetry is legible.
+
+| Byfuglien (impl chain) | Hellebuyck (spec chain) | Orthogonal: semi-formal reasoning |
+|---|---|---|
+| Layer 1: `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`, `/suggest-specs` | Layer 4 (alignment): `/invariant-coverage-scaffold`, `/protected-surface-amend` | `/reason` |
+| Layer 4 (regression): `/check-regressions` | Layer 5: `/intent-check`, `/acceptance-oracle-draft` | `/compare-patches` |
+| Spec-management bridge: `/rationale` | Layer 6: `/spec-adversary` | `/locate-fault` |
+|  | Governance index: `/assurance-init`, `/assurance-layer-audit`, `/assurance-status`, `/assurance-roadmap-check` | `/trace-execution` |
+
+The four semi-formal reasoning skills are not part of the 6-layer hierarchy. They are evidence-grounded code-analysis tools adapted from Ugare & Chandra (2026) and live as a third axis — Byfuglien-routed because they reason about implementation, but layer-agnostic.
 
 → For the full handoff seam between the two agents, see [`./docs/agents.md`](./docs/agents.md).
 
 ## Skills overview
 
-**Formal verification** — `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`. Dafny-backed proofs of business logic, with optional lightweight contracts and property-based tests when full proof is overkill.
+The persona table above maps every skill to its orchestrator and (where applicable) layer. The shape of the catalogue, by purpose:
 
-**Semi-formal reasoning** — `/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution`. Evidence-grounded code analysis adapted from "Agentic Code Reasoning" (Ugare & Chandra, 2026): premises, execution traces, and alternative-hypothesis checks before any conclusion.
+**Formal verification** — Dafny-backed proofs of business logic, with optional lightweight contracts and property-based tests when full proof is overkill.
 
-**Spec management & adequacy** — `/check-regressions`, `/suggest-specs`, `/rationale`. Keep verified specs from drifting, propose new spec targets, and bridge formal and informal verification with structured adequacy arguments.
+**Semi-formal reasoning** — evidence-grounded code analysis adapted from "Agentic Code Reasoning" (Ugare & Chandra, 2026): premises, execution traces, and alternative-hypothesis checks before any conclusion. Sits outside the 6-layer hierarchy.
 
-**Assurance hierarchy & governance** — nine skills covering Layers 4–6: `/intent-check`, `/spec-adversary`, `/acceptance-oracle-draft`, `/invariant-coverage-scaffold`, `/protected-surface-amend`, `/assurance-layer-audit`, `/assurance-init`, `/assurance-status`, `/assurance-roadmap-check`. Onboard a repo, audit its reach on the ladder, and keep governance notes from rotting.
+**Spec management & adequacy** — keep verified specs from drifting, propose new spec targets, and bridge formal and informal verification with structured adequacy arguments.
+
+**Assurance hierarchy & governance** — onboard a repo, audit its reach on the ladder, draft acceptance oracles, run the round-trip intent check, and keep governance notes from rotting.
 
 → Full skill catalogue with trigger phrases at [`./docs/skills.md`](./docs/skills.md). For the assurance flow specifically, see [`./docs/assurance-hierarchy.md`](./docs/assurance-hierarchy.md).
 

--- a/crosscheck/agents/hellebuyck.md
+++ b/crosscheck/agents/hellebuyck.md
@@ -131,7 +131,7 @@ Every result must pass these quality gates before delivery:
 **For status and maintenance output (`/assurance-status`, `/assurance-roadmap-check`):**
 - **Onboarding gate honoured** — `/assurance-status` Phase 2 runs only if Phase 1 passes; if Phase 1 fails, the output lists missing artifacts and the next-step command
 - **Drift grounded in evidence** — `/assurance-roadmap-check` cites the ROADMAP line + the contradicting repo artifact for each drift flag
-- **Kill-criterion awareness** — status output surfaces FP rate vs the 30% kill criterion and any open kill-criterion triggers
+- **Kill-criterion awareness** — status output surfaces FP rate vs the configured kill criterion (default 30%, configurable via `CROSSCHECK_FP_TRIPPED_THRESHOLD`; see `/intent-check` Configuration) and any open kill-criterion triggers
 
 **For spec-chain verification output (`/intent-check`, `/spec-adversary`):**
 - **Structural separation** — `/intent-check` uses two distinct model contexts (back-translator blind to original requirement, diff-checker compares)
@@ -153,7 +153,7 @@ If any gate fails, re-execute the skill with explicit instructions to address th
 
 ### Specification chain
 - Spec correctness is not code correctness — even a perfectly verified proof (byfuglien's domain) can be wrong if the spec doesn't capture intent; `/intent-check` is the escalation point when byfuglien's proof is clean but intent alignment is uncertain
-- Layer 5 is probabilistic — `/intent-check` reports false positives (~17–30% on real repos); enforce the 30% FP kill criterion via the per-repo FP-tracker and escalate if the rate trends up
+- Layer 5 is probabilistic — `/intent-check` reports false positives (~17–30% on real repos); enforce the configured FP kill criterion (default 30%, configurable per `/intent-check` Configuration) via the per-repo FP-tracker and escalate if the rate trends up
 - Layer 6 is best-effort — no theorem proves spec completeness; `/spec-adversary` proposes, humans triage; avoid treating its output as authoritative
 - Structural separation matters — the back-translator must be blind to the original requirement; if the two contexts share state, the check is worthless
 - Enforce onboarding before status — refuse to run `/assurance-status` Phase 2 if governance scaffolding is missing, rather than emitting a falsely-green dashboard

--- a/crosscheck/docs/reports/crosscheck-critical-analysis-reassessment.md
+++ b/crosscheck/docs/reports/crosscheck-critical-analysis-reassessment.md
@@ -1,0 +1,90 @@
+# Re-Assessment of the Crosscheck Critical Analysis
+
+The previous critic produced a thoughtful piece of work, but it was crippled by a single retrieval gap — they could not fetch GitHub `blob/` or `raw.githubusercontent.com` URLs, which means they never read the four most load-bearing documents: `docs/research/literature-review.md`, `docs/research/assurance-hierarchy.md`, the SKILL.md files, or the four internal review documents in `docs/reports/`. With the actual files in hand, the headline critique inverts. Below I keep the previous critic's structure (numbered findings; my verdict in bold) so the deltas are easy to audit.
+
+## What the critic got wrong
+
+### F1 — "The 96% has no traceable source" → **WRONG. The figure is properly attributed.**
+
+The 96% figure is **96.3%**, traced explicitly in two places the critic could not read:
+
+- `docs/research/literature-review.md:29` (Midspiral entry): *"Reported accuracy is 96.3%, acknowledged as a development benchmark rather than a formal evaluation."*
+- `docs/research/assurance-hierarchy.md:43`: *"Claimcheck reports approximately 96.3% accuracy using structural separation (two models, with the informalizer blind to the original requirement), though this is acknowledged as a development benchmark rather than a formal evaluation."*
+
+The number comes from **Midspiral's `claimcheck` tool**, not TiCoder, not Endres et al., not anything the critic speculated about. The hierarchy doc explicitly hedges that this is a development benchmark, not a formal evaluation. The critic's entire CX2 ("the 96% should be sourced... the most charitable explanation is an internal benchmark... the least charitable is someone rounded TiCoder's 90.40%") is invalidated.
+
+### F2 — "`/intent-check` is autoformalization disguised as intent formalization" → **WRONG. It's the structural-separation pattern from Midspiral claimcheck.**
+
+`/intent-check`'s SKILL.md states its lineage in the second paragraph: *"The skill is a portable analog of Midspiral's `claimcheck` and an internal Go-binary precursor."* The critical structural distinction the critic missed is in `references/round-trip-prompt.md` and in the SKILL itself:
+
+- The back-translator receives **only `{code}` and `{test}`** — never the invariant prose. The prompt says, verbatim: *"You have NOT been shown any specification or intent prose. You must describe only what the code + test enforce, not what they were meant to enforce."*
+- A **second LLM** then compares the prose intent against this independently-produced behavioural description.
+
+This is **not** autoformalization back-translation (where you translate F → NL and check it against the original NL prompt; Lahiri rejects this because the original NL is incomplete). It is **structurally adversarial**: the back-translator cannot tautologically restate the prose because it never sees it. This is exactly Lahiri's "structural separation" pattern, applied at the (code+test) layer rather than the spec layer. The critic conflated two different round-trip techniques.
+
+The skill also ships hardening the critic didn't know about: a 30% rolling-FP kill criterion, contradictory-output detection (auto-flips `match=true` with non-empty `mismatch_reason`), a truncation guard (`mismatch_reason < 20 chars` → reject), and a mandatory rationale-comment extraction (calibration finding FP #6) that the critic's "subtranslation alignment" suggestion is actually a coarser version of.
+
+### F3 — "Three of the four cited arXiv papers I could not corroborate" → **WRONG. All three exist; subagent verified.**
+
+A delegated agent verified all three on arXiv:
+
+- **Ugare & Chandra, "Agentic Code Reasoning"** (arXiv 2603.01896, March 2026) — abstract describes "semi-formal reasoning" with patch-equivalence (78%→88%, 93% real-world), Defects4J fault localization (+5pts Top-5), and code QA (87% RubberDuckBench). Maps cleanly to `/compare-patches`, `/locate-fault`, `/reason`, `/trace-execution`. `/reason`'s SKILL.md cites it by name.
+- **Murphy, Babikian & Chechik, "Abductive Vibe Coding (Extended Abstract)"** (arXiv 2601.01199, January 2026, U. Toronto) — proposes hierarchical claim trees with `(C1 ∧ … ∧ Cn) ⟹ C` decomposition. The internal review at `docs/reports/abductive-vibe-coding-review.md` documents the design choice: adopt the claim-tree shape, **reject** the paper's Lean backend in favor of prompt-driven `/rationale`.
+- **Mitchell & Shaaban, "Vibe Coding Needs Vibe Reasoning"** (arXiv 2511.00202, LMPL '25) — autoformalization side-car. The internal review at `docs/reports/vibe-reasoning-paper-review.md` is explicit about what was kept (constraint-tracking → `/check-regressions`) and what was rejected ("continuous side-car on every edit: wrong granularity for Dafny"; "bolting TypeScript type-system checks onto a Dafny-based plugin would be architectural incoherence").
+
+The critic's retrieval failure was a false negative — likely because two of the three papers post-date the January 2026 training cutoff.
+
+### F4 — "`/protected-surface-amend` may protect code rather than spec, contradicting Fowler" → **WRONG. It strictly protects governance artifacts.**
+
+The protected-surfaces partition, scaffolded by `/assurance-init` at Step 5, is **binary and exhaustive**:
+
+- **Class A — Harness/workflow definitions**: `.claude/agents/**`, `.claude/rules/**`, workflow YAMLs (`.github/workflows/**`, `.gitlab-ci.yml`), prompt templates, "any file the harness interprets as 'ground truth' for agent behaviour."
+- **Class B — Module invariant specifications and tests**: `docs/invariants/*.md` and the property-test files that cover them (e.g., `**/invariants_prop_test.{go,py,ts}`).
+
+Application source code (`src/cache.py`, business logic, anything outside these two classes) is **explicitly not** a protected surface. The amendment workflow at Step 7 even states: *"No invariant is being weakened to make a failing test pass"* — the direction is fix-the-code, not fix-the-spec, which is **exactly** Fowler-aligned. The critic's most-uncertain Fowler-vs-Crosscheck conflict (CX7) dissolves: protected surfaces are spec/intent files, not code.
+
+### F5 — "`/assurance-status`'s 'FP rate' is unclear" → **RESOLVED.**
+
+Step 2.4 of the SKILL pins it down to spec-level precision: it's the rolling 14-day false-positive rate of `/intent-check` runs, computed as `count(human_verdict=="spurious") / count(rows in window with non-empty human_verdict)`. Window must have ≥3 classified rows; verdict thresholds are `OK <20%`, `AT RISK 20-30%`, `TRIPPED ≥30%`. The 30% kill criterion takes Layer 5 offline — it is not "operational vs epistemic" handwaving as the critic suggested.
+
+### F6 — "`/spec-adversary` is mutation testing under a less rigorous name" → **PARTIALLY RIGHT, BUT THE SKILL IS HONEST ABOUT IT.**
+
+The SKILL is explicit: *"Layer 6 of the assurance hierarchy — spec completeness — has no deterministic tool. This skill operationalises the 'adversarial invariant proposer' pattern... Success is 'at least one non-obvious candidate per meaningful change,' not 'zero missed properties.'"* It uses HIGH/MEDIUM/LOW confidence + an accept/reject/defer triage block + signal-to-noise kill criteria (S/N <1:5 after 4 weeks → retire). The critic's improvement suggestion (add SPOTs/MutDafny-style mutation testing as a discrimination signal) is a fair upgrade — but it's not a misrepresentation; it's a Layer-6 best-effort tool that says so.
+
+### F7 — "Lahiri's 'Intent Formalization' is uncited" → **MISLEADING.**
+
+The critic is right that Lahiri's essay isn't cited *by name* in the README. But the literature review **does** cite Midspiral's claimcheck, which is the operational tool the essay points at. The Midspiral entry is over half a page and engages with the technique directly. This is "different citation strategy," not "ignored prior art."
+
+### F8 — "Provably correct Python/Go" overclaim in README vs. "trust your toolchain" hedge in docs → **CORRECT.**
+
+The README at line 10 says *"Dafny-verified Python or Go. The compiler refuses to emit code that doesn't satisfy its spec."* — but the docs at `docs/assurance-hierarchy.md` are honest that Layer 2 is *"Not addressed — trust your toolchain."* The critic's recommendation to rephrase the README is fair.
+
+### F9 — "Byfuglien/Hellebuyck symmetry is misleading" → **PARTIALLY CORRECT.**
+
+The README sells two-orchestrator symmetry, but the actual layer ownership is asymmetric: Byfuglien owns Layer 1 + four out-of-hierarchy semi-formal reasoning skills; Hellebuyck owns Layers 4–6 + governance. The agents.md files are honest about this; the README compresses it. Fair recommendation to surface the asymmetry.
+
+## What the critic got right
+
+- **README "six layers" framing oversells what ships** (Layers 2–3 are punted, docs say so honestly, README doesn't).
+- **`/spec-adversary` could be strengthened** with mutation-based discrimination signals (FMCAD-2024-style or SPOT-style).
+- **`/intent-check` could be strengthened** with sub-translation-style fragment alignment (nl2spec-style) — though this is additive, not corrective; the structural separation it already has is valid.
+- **Crosscheck has no TiCoder-style interactive Yes/No/Don't-know disambiguation** — true gap.
+- **The semi-formal reasoning skills sit outside the layer hierarchy** — accurate observation; they are an orthogonal third concern.
+
+## What I'd add the critic missed
+
+1. **`docs/reports/crosscheck-field-report.md` is openly self-critical**: on a Django billing case, it concludes *"The verification was correct but not useful for this task"*, *"Real bugs were elsewhere"*, *"Extracted code wasn't usable"*. This is the source of the complexity-gating and `/lightweight-verify`-as-default recommendations baked into Byfuglien's classification table. The plugin already internalises the "Dafny is too heavyweight by default" critique the critic raises.
+
+2. **`docs/research/logic-distribution-analysis.md`** is a static analysis across 14 codebases (~2.5M LOC) showing pure functions are 22–27% of full-stack web apps, with bounds 15–25% after correction. This is real empirical grounding for the reach claims that the critic treated as ungrounded.
+
+3. **`/reason` and the semi-formal reasoning skills are genuinely structured**, not marketing language. Each output requires numbered PREMISES with `[STATIC|SEMANTIC|BEHAVIORAL|FORMAL]` tags + mandatory `file:line` citations + alternative-hypothesis check + confidence assessment. The format is enforced by Byfuglien's Phase-4 validation gates, which reject outputs that skip steps.
+
+4. **The internal reviews show deliberate divergence from cited papers** — not unattributed copying. The vibe-reasoning-paper-review explicitly rejects the paper's TypeScript-template approach as "architectural incoherence" with a Dafny backend. This is the opposite of the "uncritically operationalises Ugare & Chandra" framing the critic gestured at.
+
+## Bottom line
+
+The previous critic's three load-bearing claims — (1) the 96% has no source, (2) `/intent-check` is autoformalization mismarketed as intent formalization, (3) three of four cited papers can't be corroborated — are all wrong, all because of the same retrieval gap. Once the docs/research, docs/reports, and skill SKILL.md files are read, the picture inverts: the citations are real, the technique lineage is documented, the FP-rate semantics are pinned to spec-level precision, and the protected-surface partition is governance-only (Fowler-aligned).
+
+The real remaining critique surface is much narrower: (a) the README oversells "provably correct" relative to the docs' honest "trust your toolchain"; (b) the Byfuglien/Hellebuyck symmetry hides Layer 1 ownership asymmetry; (c) `/spec-adversary` could be strengthened with mutation testing; (d) `/intent-check` could add sub-translation-style fragment alignment as a complement to (not replacement for) structural separation; (e) the semi-formal reasoning skills don't sit cleanly inside the 6-layer hierarchy. These are improvements, not credibility issues.
+
+The previous analysis should be treated as a stress-test for what the README looks like to a reader who can't open the linked docs — and the corrective is to lift more of `docs/research/literature-review.md` (specifically the Midspiral claimcheck attribution and the 96.3% figure) into the README itself, so the citation chain doesn't depend on a clickthrough that the critic's environment couldn't follow.

--- a/crosscheck/docs/research/assurance-hierarchy.md
+++ b/crosscheck/docs/research/assurance-hierarchy.md
@@ -72,9 +72,21 @@ How far each layer reaches in practice depends on the host language, the maturit
 
 **Layer 4 (implementation-spec alignment).** Reachable wherever Layer 1 is reachable. Enforced via CI gates that run `dafny_verify` on touched specs and via the `/invariant-coverage-scaffold` skill, which generates a bidirectional invariant-to-test coverage gate so every documented invariant has a covering test and every "Invariant <ID>" comment points at a real doc.
 
-**Layer 5 (spec-intent alignment).** Reachable as a probabilistic check using LLM round-trip informalization. The `/intent-check` skill implements this for invariant-prose / covering-test / code-diff triples, with a false-positive tracker and a 30% kill criterion. Expect ~96% accuracy on curated benchmarks; real-PR accuracy will only be known once it has run on protected-surface diffs for some time.
+**Layer 5 (spec-intent alignment).** Reachable as a probabilistic check using LLM round-trip informalization. The `/intent-check` skill implements this for invariant-prose / covering-test / code-diff triples, with a false-positive tracker and a configurable kill criterion (default 30% rolling FP rate over a 14-day window with `n ≥ 3` minimum sample). See "Calibration of Layer-5 thresholds" below for the rationale and the env vars that override the defaults. Expect ~96% accuracy on curated benchmarks; real-PR accuracy will only be known once it has run on protected-surface diffs for some time.
 
 **Layer 6 (spec completeness).** Best-effort. The `/spec-adversary` skill probes a module's invariant doc for missing properties, and `/acceptance-oracle-draft` generates mechanically-verifiable user-perspective scenarios as an empirical complement to invariant coverage. No theorem proves spec completeness; both are iterative practices, not gates.
+
+## Calibration of Layer-5 thresholds
+
+The Layer 5 kill criterion as currently shipped (30% rolling FP rate, 14-day window, `n ≥ 3` minimum sample size) is **founder intuition, not labelled-pilot data**. There is no calibration trace of the form "threshold set by N-day pilot, M human verdicts, trip line at distribution elbow" backing it. The numbers were chosen so that (a) Layer 5 is taken offline before it gates more than ~1 in 3 commits incorrectly, (b) the window is long enough to absorb a single bad day without tripping, and (c) the minimum sample blocks single-row noise. None of those bounds are empirically validated yet.
+
+The implementation surfaces three environment variables so each adopter can override the defaults once they have their own labelled trace:
+
+- `CROSSCHECK_FP_TRIPPED_THRESHOLD` (default `0.30`) — kill threshold.
+- `CROSSCHECK_FP_AT_RISK_THRESHOLD` (default `0.20`) — escalation threshold.
+- `CROSSCHECK_FP_WINDOW_DAYS` (default `14`) — rolling window length.
+
+The same env vars are read by `/intent-check` (Step 0 pre-check) and `/assurance-status` (Step 2.4 dashboard) so the FP rate shown to a contributor is computed identically across the two skills. The reference squad workflows in `crosscheck/docs/examples/workflows/` use the same values; tune all three together when calibrating. The Noisy-but-Valid framework (Feng et al., 2026) is one published protocol for deriving such thresholds from a labelled pilot.
 
 ## Supporting Workflow Elements
 

--- a/crosscheck/docs/research/crosscheck-review-may-2026.md
+++ b/crosscheck/docs/research/crosscheck-review-may-2026.md
@@ -1,0 +1,168 @@
+# Crosscheck: Final Synthesis
+
+*Definitive comparative assessment. Replaces all prior rounds. Reconciles four sources: an independent cold-read, an independent grounded re-read, a privileged in-repo review, and an adversarial pressure-test.*
+
+---
+
+## How this document was built
+
+This synthesis combines: (a) two independent comparative assessments produced from the original research brief, with different levels of access to the Crosscheck repo; (b) a privileged in-repo review that corrected three load-bearing factual errors in the cold-read; (c) an adversarial round-2 pressure-test that conceded those corrections and probed deeper. Where the four sources agree, the agreement is treated as established. Where they disagree, the synthesis adopts the more privileged source for facts and the more adversarial source for critique. Both round-1 cold-read claims that the privileged review demonstrated were wrong (96% unsourced; `/intent-check` mismarketed as autoformalization; cited arXiv papers can't be corroborated; protected surfaces conflict with Fowler) have been removed from this document and do not appear in the ledger.
+
+---
+
+## 1. What Crosscheck actually is
+
+Crosscheck is a Claude Code plugin that wraps a six-layer assurance model around AI-assisted coding. Layers 1–3 harden the implementation; layers 4–6 harden specifications, intent, and governance. Two orchestrator agents — Byfuglien (implementation chain) and Hellebuyck (specification chain) — route work across the layers. The plugin's claim to value is not algorithmic novelty; it is the productisation of techniques the literature has separately validated, plus a governance scaffolding (kill criteria, protected surfaces, FP trackers, invariant-coverage gates) that is closer to a research contribution in operational discipline than in any single technical primitive.
+
+The nine theoretical commitments are: (1) the *plausible vs correct* framing of LLM failure modes; (2) the *two-orchestrator split* along an impl/spec seam; (3) the *six-layer assurance hierarchy*; (4) *Dafny as Layer 1* with self-disclosed scope limits; (5) *round-trip informalization* in `/intent-check`, claimed at ~96.3% accuracy; (6) *adversarial spec probing* in `/spec-adversary`; (7) *governance scaffolding against drift* (invariant-coverage gates, protected-surface amendments, regression re-verification, FP rate / kill criteria); (8) *semi-formal evidence certificates* in `/rationale`, `/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution`; (9) *cited research grounding* in Ugare & Chandra "Agentic Code Reasoning" (arXiv 2603.01896), Murphy/Babikian/Chechik "Abductive Vibe Coding" (arXiv 2601.01199), and Mitchell & Shaaban "Vibe Coding Needs Vibe Reasoning" (arXiv 2511.00202).
+
+The factual record on each commitment, after privileged review:
+
+- **The 96.3% number is sourced.** It traces to Midspiral's `claimcheck` development benchmark (Graciolli & Amin, Feb 2026), measured on 108 comparisons across 36 requirement-lemma pairs in 5 domains, with 8 deliberately planted bogus lemmas. Both the Midspiral blog post and Crosscheck's `docs/research/literature-review.md` and `docs/research/assurance-hierarchy.md` explicitly hedge it as "a development benchmark rather than a formal evaluation." Crosscheck describes `/intent-check` as "a portable analog of Midspiral's `claimcheck` and an internal Go-binary precursor."
+
+- **`/intent-check` is structural separation, not autoformalization back-translation.** The back-translator LLM receives only `{code, test}` and is explicitly prompted that it has *not* been shown the specification or intent prose. A second LLM compares the prose intent against this independently-produced behavioural description. The pattern matches Midspiral `claimcheck` exactly. The skill ships hardenings: a 30% rolling-FP kill criterion, contradictory-output detection, a truncation guard on `mismatch_reason`, and a mandatory rationale-comment extraction.
+
+- **All three cited 2025–2026 arXiv papers exist** and Crosscheck applies them with deliberate, documented divergence. Internal review documents in `docs/reports/` show, for example, that the Lean backend from "Abductive Vibe Coding" was deferred in favour of prompt-driven `/rationale`, and the TypeScript side-car from "Vibe Coding Needs Vibe Reasoning" was rejected as architecturally incoherent with a Dafny backend (correct on reading the paper directly — the side-car is bound to TypeScript's exhaustiveness and never-typed assertions in a way that doesn't generalise to Dafny).
+
+- **Protected surfaces are governance artefacts, not application code.** The `/assurance-init` Step 5 partition is binary: Class A is harness/workflow definitions (`.claude/agents/**`, workflow YAMLs, prompt templates); Class B is invariant specifications and their property tests (`docs/invariants/*.md`, `**/invariants_prop_test.{go,py,ts}`). Application source code is explicitly excluded. The amend workflow rule "no invariant is being weakened to make a failing test pass" enforces fix-the-code-not-the-spec, which is Fowler-aligned.
+
+- **The semi-formal reasoning skills are genuinely structured.** Outputs require numbered premises tagged `[STATIC|SEMANTIC|BEHAVIORAL|FORMAL]` with mandatory `file:line` citations, an alternative-hypothesis check, and a confidence assessment. Format is enforced by Byfuglien's Phase-4 validation gates.
+
+- **`/assurance-status`'s "FP rate" is precisely defined.** Rolling 14-day false-positive rate of `/intent-check` runs, computed as `count(human_verdict=="spurious") / count(rows in window with non-empty human_verdict)`, requiring ≥3 classified rows. Thresholds: OK <20%, AT RISK 20–30%, TRIPPED ≥30%. The TRIPPED state takes Layer 5 offline.
+
+- **Crosscheck has documented, honest self-criticism.** `docs/reports/crosscheck-field-report.md` (Django billing case) concludes "the verification was correct but not useful for this task," "real bugs were elsewhere," "extracted code wasn't usable" — and the field report is presented as the source of subsequent design decisions on complexity gating and `/lightweight-verify`.
+
+- **Crosscheck has empirical reach calibration.** `docs/research/logic-distribution-analysis.md` reports static analysis across 14 codebases (~2.5M LOC) showing pure functions are 22–27% of full-stack web apps (15–25% after correction). This is the actual reach ceiling for Layer 1.
+
+---
+
+## 2. Final ledger across the nine commitments
+
+| # | Commitment | RiSE / academic | nl2spec / TiCoder | Phoenix / semi-formal | Synthesis verdict |
+|---|---|---|---|---|---|
+| 1 | Plausible vs correct framing | **Confirmed** | **Confirmed** | **Confirmed** | Settled. No remaining critique. |
+| 2 | Two-orchestrator split | **Refined** — RiSE diagnoses spec as the heavier side; Crosscheck's split is principled but presents symmetric-looking ownership while actually weighting Byfuglien at 1 layer + 4 orthogonal skills vs Hellebuyck at 3 layers + governance | Orthogonal | **Refined** — Vibe Reasoning's continuous-sidecar argument suggests Hellebuyck should own more continuous monitoring | Principled in shape, asymmetric in substance, under-disclosed in README |
+| 3 | Six-layer assurance hierarchy | Conceptually aligned but unvalidated empirically | Orthogonal | **Refined** — pace-layer thinking would partition by regeneration speed rather than verification technique | Useful as practitioner onboarding; not yet evidence-based |
+| 4 | Dafny as Layer 1 | **Confirmed in principle, constrained in scope** — Lahiri's Dafny work supports it for pure cores; FMCAD spec evaluation requires Dafny-grade specs | Orthogonal | **Constrained** — Phoenix would treat Dafny code as regenerable from spec, not as the durable artefact | Defensible for the 22–27% reach band; README overpromises beyond it |
+| 5 | `/intent-check` round-trip, ~96.3% | **Partially confirmed in technique** (structural separation is sound), **constrained in metric** (Lahiri FMCAD argues correctness/completeness should be reported, not single accuracy) | **Refined** — nl2spec's sub-translation pattern is the natural complement | **Confirmed in spirit, autonomous in execution** — TiCoder shows interactive yes/no/undefined unlocks the bottleneck, which Crosscheck currently doesn't have | Sourced and structurally sound; metric is one-dimensional and unvalidated outside the Midspiral corpus |
+| 6 | `/spec-adversary` | **Refined** — known technique under a less rigorous name; SPOTs (Swamy & Lahiri 2026), IronSpec (OSDI '24), MutDafny (2511.15403) provide deterministic discrimination signals it lacks | Orthogonal | Confirmed in spirit | Honest about its scope; could be augmented with mutation kicker on HIGH-confidence proposals |
+| 7 | Governance scaffolding | **Confirmed** | Orthogonal | **Strongly confirmed** — closest match to Phoenix's "non-deletable primitives" thesis | Crosscheck's strongest contribution; rare in the literature at this operational depth |
+| 8 | Semi-formal evidence certificates | **Directly confirmed** by Ugare & Chandra | Orthogonal | **Confirmed** — Murphy et al.'s claim trees are an abductive variant; Crosscheck adopts the shape and defers the Lean backend | Faithful adaptation; "certificate" terminology is slightly stronger than the cited papers warrant |
+| 9 | Cited research grounding | Faithful at the level of ideas; deliberate divergences are documented in internal review docs | n/a | n/a | Genuinely engaged with the literature; could foreground Lahiri's "Intent Formalization" essay (2603.17150) and FMCAD 2024 more prominently |
+
+**Where the lenses disagree about a commitment**, the disagreement is concentrated on commitment 4 (Dafny as Layer 1). Academic and Phoenix lenses point in the same direction — *lighten the integration boundary, centre evaluations and lightweight specs* — but academic accepts logical contracts as the high end of a useful spectrum, while Phoenix would treat all code (including Dafny code) as regenerable from the durable layer. Crosscheck currently sits in the academic position; the README marketing surface drifts further than the docs themselves do.
+
+---
+
+## 3. The seven cross-examinations: final answers
+
+**CX1. Right slice of the intent-formalization spectrum?** No, and academic and Phoenix lenses are pushing from the same direction. Lahiri's spectrum (tests → code contracts → logical contracts → DSLs) places the value-per-friction peak in the middle. TiCoder gets +22 to +37 percentage points pass@1 on MBPP with one user query. Endres et al. (FSE 2024) catch real Defects4J bugs with LLM-generated postconditions. Phoenix says evaluations are the codebase. Crosscheck's *anchor* at Dafny is defensible for a small, identified band of code; its *default narrative weight* on Dafny is misaligned with both lenses. The fix is the README and routing defaults, not the engine.
+
+**CX2. Does `/intent-check`'s round-trip correspond to a validated technique?** Yes. Structural separation (back-translator blind to prose) is structurally adversarial and is the same pattern Midspiral's `claimcheck` blog post articulates. The 96.3% number is sourced and self-disclaimed by its authors. The remaining critique is not provenance but base rate: 8 of 36 lemmas (22%) were *planted* bogus, which inflates the discrimination task relative to a wild distribution where real spec drift is presumably rarer than 22% of all lemmas. The number should be read as an upper bound on a synthetic benchmark, not as wild detection rate. The literature offers two complementary techniques the skill currently doesn't use: nl2spec-style fragment-level sub-translation alignment (post-hoc, after a mismatch fires) and Lahiri-FMCAD-style soundness/completeness reporting (alongside the FP rate, not replacing it).
+
+**CX3. How does `/spec-adversary` compare to mutation/completeness methods?** It's a known technique under a less rigorous name, and the SKILL is honest about that ("Layer 6 has no deterministic tool"). IronSpec (Goldweber et al., OSDI 2024) and MutDafny (arXiv 2511.15403) provide deterministic mutation-based signals against Dafny specs. The full IronSpec/MutDafny campaigns are not plugin-shaped (heavyweight, multi-node), but the *signal* — "here is a one-line mutant the spec fails to kill" — is plugin-shaped: it's one `dafny verify` call. A scoped optional `--mutate` mode that runs a fixed 5-operator MutDafny-derived set on the changed function would convert MEDIUM-confidence proposals into HIGH on objective evidence.
+
+**CX4. Does the two-agent split align with how RiSE frames the problem?** Principled in shape, asymmetric in substance. RiSE diagnoses spec validation as the bottleneck and verification as downstream. Crosscheck's actual ownership graph (Byfuglien at 1 layer + 4 orthogonal semi-formal reasoning skills; Hellebuyck at 3 layers + governance) reflects this asymmetry, but the README presents the two orchestrators as if their workloads were equal. A user who reads the README does not see this. The semi-formal reasoning skills sit *outside* the layer hierarchy entirely — they are an orthogonal third axis (Ugare-Chandra-style premise-tagged certificates), and routing them under "Byfuglien's chain" flattens the trust calculus a serious user must perform.
+
+**CX5. What does Crosscheck not do that prior art has shown matters?** The five real gaps:
+
+1. **Spec soundness/completeness metrics** in the Lahiri FMCAD sense — currently absent; FP rate is a different metric.
+2. **TiCoder-style interactive disambiguation** (yes/no/undefined on candidate tests) — absent; this is the empirically validated unlock for intent formalization at scale.
+3. **Mutation-based discrimination signals on `/spec-adversary`** — absent; would tighten Layer 6 cheaply.
+4. **Continuous verification hooks** in the Vibe Reasoning Type-III-sidecar sense — Crosscheck's flows are discrete (run-on-invocation) rather than continuous (run-on-edit).
+5. **Cross-family back-translation in `/intent-check`** — currently the back-translator is a different prompt with potentially the same model family as the spec author; correlated drift can survive structural separation.
+
+The compositionality-of-change-intent gap (Lahiri open-problem #2) is also real but is correctly out of scope for a plugin.
+
+**CX6. Where does Crosscheck genuinely advance the state of the art?** Honest answer: it doesn't advance the algorithmic SOTA, it productionises and operationalises it. Its contributions are architectural and operational. The strongest specific contributions are:
+
+- The **governance scaffolding** (kill criteria, protected surfaces, FP trackers, invariant-coverage gates as both pre-commit and CI) is operationalised at a depth few research prototypes reach.
+- The **6-layer hierarchy as practitioner onboarding** is a reusable framing tool, even though the empirical calibration of the layer model is still missing.
+- The **deployment as a Claude Code plugin** with real Dafny verification in a Docker sandbox is a real engineering artefact, not a prompt pack.
+- **The internal review documents** in `docs/reports/` (field report's Django billing post-mortem, abductive-vibe-coding-review, vibe-reasoning-paper-review) are an unusual methodological signal — Crosscheck's author publishes their own design failures and rejection reasoning, not just their successes.
+
+This is a valid finding. "Productionises existing ideas with rare operational discipline" is more durable than novelty in this space.
+
+**CX7. Is Crosscheck protecting the right artefact?** Mostly, yes. The privileged review settled the central question: protected surfaces are strictly governance artefacts (Class A: harness/workflow definitions; Class B: invariant specs and their property tests), and application source is explicitly excluded. The amend rule "no invariant is being weakened to make a failing test pass" enforces fix-the-code-not-the-spec direction. By Fowler's Deletion Test, Crosscheck passes: delete the Python/Go output and Dafny code, the invariants and acceptance oracles persist, the system is regenerable. The remaining tension is not the protected-surface partition but the README's narrative weight on Dafny Layer 1 — which can read as code-as-asset to a user who doesn't open the docs.
+
+`/acceptance-oracle-draft` is the Phoenix-aligned skill in the catalogue; both independent assessments converge on this. It deserves more prominence in the default workflow than the current docs give it.
+
+---
+
+## 4. The remaining critique surface
+
+After the privileged corrections and the adversarial pressure-test, the actual critique surface is narrower than any single round suggested. There are three categories.
+
+**Category A — Real and operational.** These argue for code or configuration changes:
+
+- **A1. Cross-family back-translation in `/intent-check`.** Structural separation defeats tautological restatement; it does not defeat correlated drift between code and tests written under the same misinterpretation of prose. The Midspiral `claimcheck` blog explicitly names this risk ("if the LLM misreads the Dafny, the comparison is comparing two wrong things"). Running the back-translator under a different model family than the code/spec drafter partially decorrelates the drift.
+- **A2. Optional MutDafny-derived mutation kicker on `/spec-adversary`.** A 5-operator scoped mode (relational-operator swap, off-by-one, conditional negation, return-value zeroing, default-value substitution) with a 60-second budget would give HIGH-confidence proposals an objective tie-breaker. Keeps the SKILL's "best-effort" framing intact.
+- **A3. Post-mismatch sub-translation alignment in `/intent-check`.** When `match=false` fires, run a single follow-up call that produces nl2spec-style `(prose-span, formal-fragment)` pairs to localise the divergence. Cost: one extra API call per mismatch. Benefit: the field-report-style "verification was correct but not useful" failure mode becomes actionable.
+- **A4. Calibration of the 30% kill threshold.** Either cite a labelled trace ("threshold set by N-day pilot, M human verdicts, trip line at distribution elbow") or label the threshold as "founder intuition pending operational data" and make it configurable. The Noisy-but-Valid framework (Feng et al., arXiv:2601.20913) is the published protocol for deriving such thresholds.
+
+**Category B — Real and architectural.** These argue for catalogue and documentation reshape:
+
+- **B1. README chain-of-trust on Layer 1.** "Provably correct Python/Go" should be replaced with "Verified in Dafny (Layer 1); compiled to Python/Go via the Dafny backends; embedding correctness is your responsibility." The docs already say this; the README just needs to inherit the docs' register.
+- **B2. README reach-ceiling disclosure.** State once that Layer 1 targets pure functional cores at empirically 22–27% of typical full-stack codebases per `docs/research/logic-distribution-analysis.md`, with the remaining ~75% governed by Layers 3–6.
+- **B3. Persona / orthogonal-axis disclosure.** Add a one-paragraph table to the README that names skills under each persona and flags the four semi-formal reasoning skills (`/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution`) as orthogonal to both — they belong in a third column, not under either persona. Resolves both the symmetry-illusion and the layer-vs-non-layer flattening.
+- **B4. Skill-catalogue consolidation toward Phoenix-style primitives.** The current catalogue has substantial breadth (verify-core-logic, maintain-invariants, maintain-evaluations, govern-protected-surfaces, probe-specs is a candidate five-primitive grouping). Single entrypoint per primitive with subcommands rather than a flat skill list reduces cognitive load and makes the architectural shape legible.
+- **B5. Default-workflow re-centring on evaluations.** The default Crosscheck path should be: `/assurance-init` → `/acceptance-oracle-draft` → interactive disambiguation (new skill, see C2 below) → optional Dafny Layer 1. This aligns the user mental model with both Phoenix and the intent-formalization literature without changing what the engine does.
+
+**Category C — Real and methodological.** These argue for adding capabilities the literature has shown matter:
+
+- **C1. Lahiri-FMCAD-style soundness/completeness metrics.** Implement a `/spec-eval` skill that, given a Dafny spec and its tests, computes correctness and completeness scores via Hoare-triple encoding with mutated outputs. For modules with invariant docs but no Dafny code, approximate via property tests and mutation testing. Surface alongside FP rate, not as a replacement.
+- **C2. TiCoder-style interactive test clarification.** Add a mode where Crosscheck proposes tests or acceptance scenarios and asks the user yes/no/undefined. Use responses to prune scenarios and refine invariants. Track pass@k@m and accept@m. This is the empirically validated unlock for intent formalization that Crosscheck currently has no analogue for.
+- **C3. Continuous verification hooks (Vibe Reasoning Type-III sidecar).** A lightweight CI mode or daemon that runs invariant coverage, `/intent-check` on protected surfaces, and acceptance oracles on a schedule or per-branch basis, rather than only on manual invocation. Prioritises by change impact and past failures.
+- **C4. SPOTs-inspired spec gap probe.** Generate small proof-oriented tests for Dafny modules or property tests; measure whether invariants/specs fail when they should. Complements `/spec-adversary` with deterministic gap detection.
+
+Categories that **dissolve** post-corrections: 96% is unsourced (it's sourced); `/intent-check` is autoformalization mismarketed (it's structural separation); cited papers can't be corroborated (they exist); protected surfaces conflict with Fowler (they are governance-only).
+
+---
+
+## 5. Threats to validity that hold up
+
+Six assumptions in Crosscheck that the prior art puts pressure on, in order of severity:
+
+1. **The 6-layer hierarchy is normative, not empirically calibrated.** No data exists yet on which layers catch real bugs, how often kill criteria fire, or what false-negative rates look like across the layer stack. This is the largest gap between Crosscheck-as-documented and Crosscheck-as-evidence-based.
+2. **`/intent-check` is treated as a hard merge gate, but its quantitative basis is one-dimensional.** Single-accuracy on a synthetic discrimination task with a 22% planted-error base rate is not a soundness/completeness statement. Until C1 ships, the gate carries more weight than the metric supports.
+3. **Invariant docs are treated as ground truth.** `/intent-check` and `/spec-adversary` build on top of them. RiSE and FMCAD 2024 both show specs themselves can be wrong, weak, or vacuous. Until spec-quality metrics are integrated, the machinery rests on unaudited foundations.
+4. **High-discipline maintenance is assumed.** Protected surfaces, invariant coverage gates, FP trackers, and governance notes only work if a team consistently maintains them. Without strong automation and clear payoff signals, governance scaffolding decays — the documented Django billing field-report case is a partial canary for this.
+5. **Skill-catalogue complexity itself.** A large flat catalogue increases cognitive load. The Phoenix lens specifically warns that breadth-as-architecture is "better prompts dressed as architecture." The 5-primitive consolidation in B4 is the targeted fix.
+6. **Dafny-verified cores dominate risk.** In many real systems, the most serious bugs live in I/O, concurrency, and integration logic — exactly where Dafny cannot reach. Treating Layer 1 as "the hard part" risks under-investing in Layers 2–3 where most production failures actually occur.
+
+---
+
+## 6. Improvements ranked by impact-to-effort
+
+Combining the operational, architectural, and methodological items above:
+
+**Tier 1 — high impact, low effort.** README chain-of-trust on Layer 1 (B1). Reach-ceiling disclosure (B2). Persona / orthogonal-axis disclosure (B3). Default-workflow re-centring (B5). Threshold calibration disclosure (A4). Cite Lahiri's "Intent Formalization" essay and FMCAD 2024 prominently. All of these are documentation changes the docs already support; the README just needs to inherit the docs' register.
+
+**Tier 2 — high impact, medium effort.** Cross-family back-translation in `/intent-check` (A1). Post-mismatch sub-translation alignment (A3). Optional mutation kicker on `/spec-adversary` (A2). TiCoder-style interactive disambiguation as a new skill (C2). Skill-catalogue consolidation into ~5 Phoenix-style primitives (B4).
+
+**Tier 3 — medium-to-high impact, medium-to-high effort.** Lahiri-FMCAD soundness/completeness metrics (`/spec-eval`, C1). Continuous verification hooks / Type-III sidecar mode (C3). SPOTs-inspired spec gap probe (C4).
+
+**Tier 4 — high impact, high effort, longer horizon.** Empirical calibration of the 6-layer hierarchy itself: instrument the plugin to publish *which layer caught what*, *which kill criteria fired and when*, and *what fraction of the codebase reached each layer*. Without this, the hierarchy remains an elegant theory rather than evidence-based engineering practice. This is the single largest gap between Crosscheck-as-documented and Crosscheck-as-justified.
+
+The single highest-leverage move is the consolidation of the documentation surface — Tier 1 above, plus a one-page "Honest Map" at the top of the README that lists each layer, what it actually guarantees, what fraction of code it reaches, who owns the skill, which cited paper it derives from, and the kept-vs-deferred decision in one column. Every Tier-1 item is a specific piece of that map. Every documented round-1 misreading would have been prevented by it. The docs already contain every word of the map; surfacing it as the *first* thing a prospective user reads converts a class of predictable misreadings into non-issues without changing a single piece of code.
+
+---
+
+## 7. Open questions
+
+These remained unresolvable from outside the repo and depend on author intent or unpublished implementation details:
+
+1. **Has the 96.3% been re-measured on a non-Midspiral corpus?** The number is sourced and self-disclaimed by its authors. It has not, to public knowledge, been validated on Crosscheck's own all-LLM port against user repositories.
+2. **Is `/lightweight-verify`-as-default actually wired into the workflow YAMLs**, or is the recommendation documentary while the inherited Dafny-by-default routing is what actually runs? The field report grounds the recommendation; the wiring is what tests whether the lesson was internalised.
+3. **What is the calibration trace behind the 30% FP kill threshold?** Founder intuition or labelled-pilot data?
+4. **Have any cross-layer interactions been documented over time on a multi-module system?** End-to-end workflows for combining Dafny Layer 1 with Hellebuyck's Layers 4–6 are sketched but not, as far as I could verify, demonstrated on a realistic case study.
+5. **Does the Intent Stack reference framework (intentstack.org) inform Crosscheck's layer model directly, or is the convergence on layered governance independent?** The parallel agent's report names the Intent Stack as a peer; Crosscheck's docs do not appear to engage with it explicitly.
+6. **What is Crosscheck's empirical layer-attribution data?** Tier 4 above. If even a small labelled trace exists internally — "in N runs, layer X caught M bugs" — publishing it would be the single most credibility-enhancing artefact the plugin could ship.
+
+---
+
+## 8. Net assessment
+
+Crosscheck is a serious, methodologically honest plugin that productionises a slice of the AI-coding-assurance literature with rare operational discipline. Its contributions are architectural and operational rather than algorithmic: the governance scaffolding (kill criteria, FP trackers, protected surfaces, invariant-coverage gates as both pre-commit and CI), the 6-layer onboarding framing, the publication of internal failure post-mortems, the deliberate documented divergence from cited papers (Lean deferred, TS side-car rejected). These are the durable contributions, and they are unusual in the field at this depth. The Dafny verification engine and the structural-separation `/intent-check` skill are faithful adaptations of upstream work (Midspiral `claimcheck`, the Dafny ecosystem, Ugare-Chandra reasoning), not novel primitives.
+
+The actionable critique surface is narrower than the round-1 cold-read suggested but real: a documentation surface that consistently overpromises relative to honest underlying docs; a 96.3% number whose base rate is more synthetic than the framing implies; a `/spec-adversary` skill that could be sharpened cheaply with mutation kickers; an `/intent-check` skill that could add cross-family back-translation and post-mismatch sub-translation alignment without violating its existing design; a missing TiCoder-style interactive layer where the literature shows the largest empirical unlock; a six-layer hierarchy that remains uncalibrated against real bug-catch data. The single highest-leverage change is documentary, not algorithmic: a one-page "Honest Map" at the top of the README that surfaces what the docs already say. The pattern across multiple independent assessments is consistent: when the README is read cold, certain misreadings are predictable; when the docs are read in full, they are usually right. That asymmetry is the one thing worth fixing first, because it would prevent the next critic from spending three rounds rediscovering the same thing.

--- a/crosscheck/docs/skills.md
+++ b/crosscheck/docs/skills.md
@@ -39,7 +39,7 @@ Exhaustive index of all 20 skills in the crosscheck plugin, grouped by category.
 
 | Skill | Trigger phrases | One-line summary | Owner |
 |-------|----------------|------------------|-------|
-| [`/intent-check`](../skills/intent-check/SKILL.md) | "intent check", "round-trip check", "spec-intent alignment" | Round-trip informalisation over (invariant prose, covering test, code diff) with FP tracking and a 30% kill criterion. | hellebuyck |
+| [`/intent-check`](../skills/intent-check/SKILL.md) | "intent check", "round-trip check", "spec-intent alignment" | Round-trip informalisation over (invariant prose, covering test, code diff) with FP tracking and a configurable kill criterion (default 30%, see SKILL Configuration). | hellebuyck |
 | [`/acceptance-oracle-draft`](../skills/acceptance-oracle-draft/SKILL.md) | "acceptance oracle", "draft scenarios", "user-observable flows" | Draft mechanically-verifiable user-flow acceptance scenarios; rejects subjective criteria. | hellebuyck |
 
 ## Assurance hierarchy — Layer 6 (spec completeness)

--- a/crosscheck/skills/assurance-status/SKILL.md
+++ b/crosscheck/skills/assurance-status/SKILL.md
@@ -19,6 +19,18 @@ Report the current state of the 6-layer assurance hierarchy in the target repo. 
 
 The skill is read-only. It does not modify files, write attestations, or kick off verification jobs — it reports. Remediation is delegated to sibling skills (`/assurance-init`, `/assurance-layer-audit`, `/assurance-roadmap-check`, `/intent-check`, `/protected-surface-amend`).
 
+## Configuration
+
+The kill-criterion thresholds used in Step 2.4 are configurable via environment variables. Read these once at the start of the skill run; if unset, use the documented defaults.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `CROSSCHECK_FP_TRIPPED_THRESHOLD` | `0.30` | Rolling FP rate at which Layer 5 is taken offline |
+| `CROSSCHECK_FP_AT_RISK_THRESHOLD` | `0.20` | Rolling FP rate at which the dashboard escalates to AT RISK |
+| `CROSSCHECK_FP_WINDOW_DAYS` | `14` | Rolling-window length used to compute the FP rate |
+
+The defaults (30% / 20% / 14 days, with `n ≥ 3` minimum sample size) are **founder intuition, not labelled-pilot data**. Tune them for your tolerance once you have ≥30 classified human verdicts. See `docs/research/assurance-hierarchy.md` for the calibration rationale and `docs/examples/workflows/README.md` for how the same numbers are surfaced in the reference squad workflows.
+
 ## Instructions
 
 You are the assurance-hierarchy status reporter. Your job is to tell the user whether their repo is onboarded onto the hierarchy and, if it is, what has drifted since the last check. You run in two phases and **never skip Phase 1**.
@@ -123,12 +135,12 @@ Read `.assurance/intent-check-fp-tracker.csv` (columns: `date,invariant_touched,
 
 - If the file does not exist, note "FP tracker not initialised" and recommend `/intent-check` to establish the tracker.
 - If it exists, use the canonical FP-rate definition from `/intent-check` (see `references/fp-tracker-schema.md` in that skill — the pseudocode there is authoritative):
-  1. Filter rows to the rolling 2-week window ending today (`date` within 14 days).
+  1. Filter rows to the rolling window ending today (`date` within `CROSSCHECK_FP_WINDOW_DAYS`, default 14).
   2. Exclude rows with empty `human_verdict` from both numerator and denominator — they are awaiting review and bias the rate either way.
   3. Let `window_size = count(rows in window with non-empty human_verdict)`. If `window_size == 0`, report sample size 0 and verdict `INSUFFICIENT DATA` — do not compute a rate or compare against the kill criterion.
   4. Otherwise, compute `FP rate = count(human_verdict == "spurious") / window_size`. `partial` does NOT count as spurious (the pipeline was still doing useful work).
-  5. Compare against the 30% kill criterion.
-  6. Report the rolling rate, `window_size`, and the verdict: `OK` if below 20%, `AT RISK` if 20% ≤ rate < 30%, `TRIPPED` if rate ≥ 30%.
+  5. Compare against the kill criterion: `tripped = CROSSCHECK_FP_TRIPPED_THRESHOLD` (default `0.30`), `at_risk = CROSSCHECK_FP_AT_RISK_THRESHOLD` (default `0.20`). The defaults are founder intuition, not labelled-pilot data — see the Configuration section.
+  6. Report the rolling rate, `window_size`, and the verdict: `OK` if `rate < at_risk`, `AT RISK` if `at_risk ≤ rate < tripped`, `TRIPPED` if `rate ≥ tripped`.
 
 If `TRIPPED`, surface it prominently in Step 2.6.
 
@@ -146,7 +158,7 @@ If no `*.dfy` files exist, skip this section and note "No Dafny kernels in repo 
 
 Re-read the ROADMAP's kill-criteria section (if present) and any per-item kill criteria in the horizon docs. Cross-reference against the evidence gathered above:
 
-- intent-check FP rate ≥ 30% → kill criterion tripped.
+- intent-check FP rate ≥ `CROSSCHECK_FP_TRIPPED_THRESHOLD` (default 30%) → kill criterion tripped.
 - Any item-level kill criterion that the earlier steps flagged as met.
 - Any Status drift that explicitly references a kill-criterion trigger (e.g. "If Immediate item X not landed in 4 weeks, re-plan").
 
@@ -185,10 +197,10 @@ Present the full dashboard in this order:
 
 (or: "None in last 30 days.")
 
-### intent-check FP tracker (rolling 2 weeks)
+### intent-check FP tracker (rolling <window> days, default 14)
 - Sample size: N
 - False positives: M
-- FP rate: X%  (kill criterion: 30%)
+- FP rate: X%  (kill criterion: <tripped_threshold>%, default 30%)
 - Verdict: OK | AT RISK | TRIPPED | INSUFFICIENT DATA
 
 ### verify-kernel
@@ -196,7 +208,7 @@ Present the full dashboard in this order:
 - Status: <pass | fail | unknown | N/A>
 
 ### Kill-criterion triggers
-- [TRIPPED] intent-check FP rate ≥ 30% — see next/07 (if applicable)
+- [TRIPPED] intent-check FP rate ≥ tripped threshold (default 30%) — see next/07 (if applicable)
 - (or: "None tripped.")
 
 ### Recommended next steps
@@ -217,7 +229,7 @@ Keep the dashboard terse. The caller runs this often; verbosity erodes signal.
 - [ ] ROADMAP drift was computed against the `Not started / In progress / Blocked / Done / Deferred` vocabulary only — no other status values accepted
 - [ ] Invariant coverage used the repo's coverage-script output when available, not ad-hoc grep, before falling back to grep
 - [ ] Protected-surface review window is explicit (default 30 days) and stated in the dashboard
-- [ ] FP-tracker rate was computed over the rolling 2-week window and compared against the 30% kill criterion
+- [ ] FP-tracker rate was computed over the configured rolling window (default 14 days) and compared against the configured kill criterion (default 30%); the defaults were sourced from the Configuration section, not hardcoded
 - [ ] verify-kernel section was skipped cleanly if no `*.dfy` files exist
 - [ ] Every tripped kill criterion was surfaced in Step 2.6 with a link to its horizon doc
 - [ ] Recommended next steps point at sibling skills (`/assurance-init`, `/assurance-layer-audit`, `/assurance-roadmap-check`, `/intent-check`, `/invariant-coverage-scaffold`, `/protected-surface-amend`) rather than proposing ad-hoc fixes

--- a/crosscheck/skills/intent-check/SKILL.md
+++ b/crosscheck/skills/intent-check/SKILL.md
@@ -17,14 +17,26 @@ argument-hint: "[optional: invariant doc path] [optional: covering test path]"
 
 Operationalise Layer 5 (spec-intent alignment) of the assurance hierarchy as a portable, repo-agnostic Claude Code skill. The input is a triple — an **invariant prose description**, a **covering property test**, and the **code diff** the user wants to ship. The output is a structured verdict (match / mismatch + confidence + reason), an appended row in a per-repo false-positive tracker CSV, and a content-hashed JSON attestation that a companion pre-commit hook can check without invoking an LLM.
 
-The skill is a portable analog of Midspiral's `claimcheck` and an internal Go-binary precursor. It is structurally adversarial by construction: the back-translator is **blind to the original intent prose**, so it cannot tautologically restate it, and the diff-checker is forced to scan for carve-outs and rationale comments before rendering a verdict. These two prompt-level guardrails are the Phase-1 calibration fixes that drive the false-positive rate below the 30% kill criterion.
+The skill is a portable analog of Midspiral's `claimcheck` and an internal Go-binary precursor. It is structurally adversarial by construction: the back-translator is **blind to the original intent prose**, so it cannot tautologically restate it, and the diff-checker is forced to scan for carve-outs and rationale comments before rendering a verdict. These two prompt-level guardrails are the Phase-1 calibration fixes that drive the false-positive rate below the configurable kill criterion (default 30%, see Configuration).
 
 This is a methodology skill. It does not ship a binary — Claude drives the pipeline itself, reading files, invoking the two prompts in the required order, writing the tracker row and the attestation, and running the kill-criterion math before committing. The companion pre-commit hook (described in `references/attestation-schema.md`) is fast and LLM-free: it only checks hashes and verdicts.
 
 Cross-references:
 - `references/round-trip-prompt.md` — verbatim two-prompt template for back-translator + diff-checker, including rationale extraction and carve-out taxonomy.
-- `references/fp-tracker-schema.md` — CSV schema, append logic, and the 30% kill-criterion computation.
+- `references/fp-tracker-schema.md` — CSV schema, append logic, and the kill-criterion computation.
 - `references/attestation-schema.md` — JSON attestation format, SHA-256 computation, and pre-commit hook pseudocode.
+
+## Configuration
+
+The kill-criterion thresholds in Step 0 are configurable via environment variables. Read these once at the start of the skill run; if unset, use the documented defaults.
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `CROSSCHECK_FP_TRIPPED_THRESHOLD` | `0.30` | Rolling FP rate at which Step 0 refuses to run (Layer 5 offline) |
+| `CROSSCHECK_FP_AT_RISK_THRESHOLD` | `0.20` | Rolling FP rate at which the verdict reports `AT RISK` |
+| `CROSSCHECK_FP_WINDOW_DAYS` | `14` | Rolling-window length used to compute the FP rate |
+
+The defaults (30% / 20% / 14 days, with `n ≥ 3` minimum sample size) are **founder intuition, not labelled-pilot data**. Tune them for your tolerance once you have ≥30 classified human verdicts. See `docs/research/assurance-hierarchy.md` for the calibration rationale and `docs/examples/workflows/README.md` for how the same numbers are surfaced in the reference squad workflows. Schema parity matters: any consumer that reads `.assurance/intent-check-fp-tracker.csv` (e.g. `/assurance-status`) must use the same env vars so the user sees the same rate everywhere.
 
 ## Instructions
 
@@ -34,13 +46,15 @@ You are running a two-LLM round-trip informalization pipeline over one protected
 
 Before doing any LLM work, open `.assurance/intent-check-fp-tracker.csv` (create it if missing; see `references/fp-tracker-schema.md` for the exact header).
 
-Compute the rolling false-positive rate over the **last 2 weeks of entries** (rows where `date` is within 14 days of today **AND `human_verdict` is non-empty** — empty cells are awaiting review and are excluded from both numerator and denominator; see the pseudocode in `references/fp-tracker-schema.md`):
+Read the threshold env vars from the Configuration section: `tripped = CROSSCHECK_FP_TRIPPED_THRESHOLD` (default `0.30`) and `window = CROSSCHECK_FP_WINDOW_DAYS` (default `14`). The defaults are founder intuition, not labelled-pilot data — see the Configuration section.
+
+Compute the rolling false-positive rate over the last `window` days of entries (rows where `date` is within `window` days of today **AND `human_verdict` is non-empty** — empty cells are awaiting review and are excluded from both numerator and denominator; see the pseudocode in `references/fp-tracker-schema.md`):
 
 - FP rate = count(`human_verdict` == `spurious`) / count(rows in window with non-empty `human_verdict`)
 - If the window has fewer than 3 classified rows, treat the rate as unknown and proceed with a warning.
-- If the FP rate **> 30%**, refuse to run. Tell the user:
+- If the FP rate **> `tripped`**, refuse to run. Tell the user:
 
-  > The Layer-5 round-trip pipeline's rolling false-positive rate is `<rate>%` over the last 14 days (threshold: 30%). The kill criterion in the assurance hierarchy says this layer's strategy needs rework before it keeps gating commits. Do not re-enable until (a) the prompt or model is revised, or (b) human review has reclassified enough entries to drop the rate below 30%. See `references/fp-tracker-schema.md` for the exact computation.
+  > The Layer-5 round-trip pipeline's rolling false-positive rate is `<rate>%` over the last `<window>` days (threshold: `<tripped>%`, default 30%). The kill criterion in the assurance hierarchy says this layer's strategy needs rework before it keeps gating commits. Do not re-enable until (a) the prompt or model is revised, or (b) human review has reclassified enough entries to drop the rate below the threshold. See `references/fp-tracker-schema.md` for the exact computation and the Configuration section above for the threshold env vars.
 
   Stop. Do not proceed to Step 1.
 
@@ -168,7 +182,7 @@ Present a single summary block to the user:
 Tracker row appended: .assurance/intent-check-fp-tracker.csv
 Attestation written:   .assurance/intent-check-attestation.json
 
-Rolling 14-day FP rate: <rate>% (threshold 30%)
+Rolling FP rate (last <window> days): <rate>%  (threshold: <tripped>%, default 30%)
 ```
 
 If `match == false`, tell the user exactly what the back-translator perceived vs. what the invariant prose claimed, so they can decide whether to fix the code, fix the test, or amend the invariant prose via `/protected-surface-amend`.
@@ -178,7 +192,7 @@ If `match == false`, tell the user exactly what the back-translator perceived vs
 ```
 ## Verification Checklist
 
-- [ ] Kill-criterion pre-check ran before any LLM call (rolling 14-day FP rate < 30%)
+- [ ] Kill-criterion pre-check ran before any LLM call (rolling FP rate over the configured window is below the configured tripped threshold; defaults are 14 days and 30%, both sourced from the Configuration section, not hardcoded)
 - [ ] Back-translator prompt received only {code, test} — never the invariant prose
 - [ ] Back-translation contains both Section 1 (behavioural guarantees) and Section 2 (rationale comments, verbatim with file:line)
 - [ ] Diff-checker performed the mandatory Step 1 carve-out scan before rendering a verdict

--- a/crosscheck/skills/intent-check/references/fp-tracker-schema.md
+++ b/crosscheck/skills/intent-check/references/fp-tracker-schema.md
@@ -1,8 +1,8 @@
 # FP tracker CSV — schema, append logic, kill-criterion computation
 
-`/intent-check` appends one row to `.assurance/intent-check-fp-tracker.csv` per pipeline run. The tracker is the only persistent record of round-trip verdicts and is the input to the 30% kill criterion that decides whether Layer 5 stays online.
+`/intent-check` appends one row to `.assurance/intent-check-fp-tracker.csv` per pipeline run. The tracker is the only persistent record of round-trip verdicts and is the input to the configurable kill criterion (default 30% rolling FP rate over a 14-day window) that decides whether Layer 5 stays online.
 
-The schema is inherited verbatim from the upstream design referenced in `../../../docs/research/assurance-hierarchy.md`. Parity is deliberate — keeping the columns, types, and enum values fixed means calibration work done in one repo transfers cleanly to the next.
+The schema is inherited verbatim from the upstream design referenced in `../../../docs/research/assurance-hierarchy.md`. Parity is deliberate — keeping the columns, types, and enum values fixed means calibration work done in one repo transfers cleanly to the next. The numerical thresholds are not part of the schema; they are configurable via the env vars listed in the parent SKILL's "## Configuration" section.
 
 ## Schema
 
@@ -79,13 +79,14 @@ Claude runs these steps in order:
 
 Never mutate existing rows. If the user wants to correct an earlier `human_verdict`, they edit the CSV by hand.
 
-## 30% kill-criterion computation
+## Kill-criterion computation (default 30% over 14 days, configurable)
 
-The kill criterion says: if the rolling false-positive rate over the last 14 days of entries exceeds 30%, Layer 5 is not earning its cost and the pipeline must not keep gating commits.
+The kill criterion says: if the rolling false-positive rate over the last `CROSSCHECK_FP_WINDOW_DAYS` days of entries exceeds `CROSSCHECK_FP_TRIPPED_THRESHOLD`, Layer 5 is not earning its cost and the pipeline must not keep gating commits. Defaults are 14 days and `0.30`. Both are configurable per the parent SKILL's "## Configuration" section.
 
-**Pseudocode:**
+**Pseudocode** (defaults shown; substitute env-var values when configured):
 
 ```python
+import os
 from datetime import date, timedelta
 
 def kill_criterion_fp_rate(rows: list[dict], today: date) -> tuple[float, int]:
@@ -94,7 +95,8 @@ def kill_criterion_fp_rate(rows: list[dict], today: date) -> tuple[float, int]:
     Rows with empty human_verdict are ignored.
     Rows with human_verdict=='partial' count as NOT spurious.
     """
-    cutoff = today - timedelta(days=14)
+    window_days = int(os.environ.get("CROSSCHECK_FP_WINDOW_DAYS", "14"))
+    cutoff = today - timedelta(days=window_days)
     window = [
         r for r in rows
         if date.fromisoformat(r["date"]) >= cutoff
@@ -106,18 +108,18 @@ def kill_criterion_fp_rate(rows: list[dict], today: date) -> tuple[float, int]:
     return (spurious / len(window), len(window))
 ```
 
-Skill behaviour against this number:
+Skill behaviour against this number (let `tripped = CROSSCHECK_FP_TRIPPED_THRESHOLD`, default `0.30`):
 
-| `window_size` | `fp_rate`       | Skill action                                                                              |
-|---------------|-----------------|-------------------------------------------------------------------------------------------|
-| 0             | N/A             | Proceed with a warning; note the tracker is empty and no kill-criterion signal is available. |
-| 1–2           | any             | Proceed with a warning; sample too small to trust.                                         |
-| >= 3          | <= 30%          | Proceed silently.                                                                         |
-| >= 3          | > 30%           | **Refuse to run.** Emit the kill-criterion message from Step 0 of the skill.              |
+| `window_size` | `fp_rate`        | Skill action                                                                              |
+|---------------|------------------|-------------------------------------------------------------------------------------------|
+| 0             | N/A              | Proceed with a warning; note the tracker is empty and no kill-criterion signal is available. |
+| 1–2           | any              | Proceed with a warning; sample too small to trust.                                         |
+| >= 3          | `<= tripped`     | Proceed silently.                                                                         |
+| >= 3          | `> tripped`      | **Refuse to run.** Emit the kill-criterion message from Step 0 of the skill.              |
 
-Why 30%: the threshold is inherited from the upstream design (see `../../../docs/research/assurance-hierarchy.md` for the rationale). A pipeline that cries wolf more than ~1 time in 3 erodes trust faster than the spec-intent drift it was meant to catch.
+Why the 30% default: a pipeline that cries wolf more than ~1 time in 3 erodes trust faster than the spec-intent drift it was meant to catch. The number is **founder intuition, not labelled-pilot data** — see `../../../docs/research/assurance-hierarchy.md`'s "Calibration of Layer-5 thresholds" section for the rationale and the override mechanism.
 
-Why 14 days: matches the "2 weeks of live operation" acceptance criterion from the same source. Short enough that a recent prompt regression trips the kill quickly; long enough that a single bad day doesn't overreact.
+Why the 14-day default: matches the "2 weeks of live operation" acceptance criterion from the same source. Short enough that a recent prompt regression trips the kill quickly; long enough that a single bad day doesn't overreact. Same caveat applies — defaults, not validated thresholds.
 
 Why ignore empty `human_verdict`: the reviewer hasn't ruled yet. Counting empty cells either way biases the rate. The cost is that a repo with zero human review will see `window_size=0` forever — that is the correct signal (no evidence either way).
 


### PR DESCRIPTION
## Summary

Phase 1 of the post–May-2026-review remediation plan. Two atomic commits:

1. **`feat(crosscheck)`** — A4: make the Layer-5 FP kill threshold configurable via env vars and label the defaults as "founder intuition pending operational data" across the plugin's own SKILL.md / agent / reference / catalogue files. Phase 0 already added this disclaimer to the squad reference workflows; this propagates it to the plugin proper.
2. **`docs(crosscheck)`** — B1 + B3 + B5: rewrite the README so it inherits the docs' honest register. Replace "provably correct Python/Go" with chain-of-trust language, fix the wrong "Layers 1–3" claim for Byfuglien (it's actually Layer 1 + the regression slice of Layer 4 + four orthogonal semi-formal reasoning skills), insert a 3-column persona/orthogonal-axis table, and re-centre the default workflow on `/acceptance-oracle-draft` with Dafny Layer 1 as "optional, when the code shape supports it" (22–27% empirical reach band per `docs/research/logic-distribution-analysis.md`).

`B2` (reach-ceiling disclosure) and `B4` (catalogue consolidation) are explicitly deferred to a future phase per user direction.

## Verification gates passed during the work

Each Phase-1 item ran through one or two crosscheck-skill / orchestrator-agent self-reviews before merging into the working tree:

| Item | Gate | Outcome |
|---|---|---|
| A4 | `crosscheck:hellebuyck` self-review on disclaimer wording parity vs `docs/examples/workflows/README.md` | GREEN; 2 AMBERs flagged + applied (rolling-window string in dashboard template, missing "default" qualifier in prose claim) |
| B1 | `crosscheck:hellebuyck` self-review on chain-of-trust register vs `docs/research/assurance-hierarchy.md` | 1 RED + 2 AMBERs flagged + applied (Layer 2 was conflated with Layer 3 via "compiler + runtime"; "trust your toolchain" register softened to docs-aligned "trusted computing base"; "verified at the spec level" → "verified against its spec") |
| B3 | `crosscheck:byfuglien` `/reason` evidence-grounded certificate on the persona table | **PASS, HIGH confidence**. Every cell of the 3-column table cross-checked against `byfuglien.md`, `docs/research/assurance-hierarchy.md`, and `docs/skills.md` with no counterexamples |
| B5 | `crosscheck:hellebuyck` self-review on the default-workflow ordering vs each SKILL's own "when to use" prose | 1 RED + 2 AMBERs flagged + applied (`/spec-adversary` "for stable modules" was editorial gloss; `/acceptance-oracle-draft` Layer 5 framing hedged to "alongside the hierarchy"; weekly cadence was muted, now restored alongside `/assurance-roadmap-check`) |
| Final | `crosscheck:hellebuyck` integration sweep across all four items | "Needs minor fixes" → 3 one-line edits applied (96% accuracy hedge in README, `docs/skills.md` and `agents/hellebuyck.md` 30% mentions) |

Detailed orchestrator output lives in the conversation; the structured `/reason` certificate's premises and counterexample search are referenced in the B3 commit body.

## Test plan

- [ ] Visual smoke test: open `crosscheck/README.md` on GitHub and confirm the persona table renders cleanly (column 3 has 4 single-token cells; column 1 carries the longest skill lists)
- [ ] Re-run the Phase-0 reference workflows mentally: do `assurance_squad_select.py` and the dashboard template still align with the plugin's own SKILL.md after the A4 propagation? (Checked during Hellebuyck integration sweep — green.)
- [ ] Read the new "Recommended order" block as a new user: does it suggest `/acceptance-oracle-draft` early enough that the user mental model is "evaluations first"?
- [ ] Read the new "## The two orchestrator agents" section: does the asymmetry-in-substance disclosure read as honest rather than apologetic?

## Out of scope

- B2 reach-ceiling disclosure (separate, lighter follow-up)
- B4 catalogue consolidation (Phase 2, with its own ADR)
- Tier-2 items: A1 cross-family back-translation, A2 mutation kicker, A3 sub-translation, C2 TiCoder-style interactive disambiguation
- Generalising `/intent-check` to operate on README ↔ docs prose
- Runtime enforcement of the Configuration env vars (skills are prompt-driven, configurability is documentary)

## Notes for reviewer

- Phase 0 work (commits 8f86dde, c120893) is on local `main` but not on origin yet — it's intentionally not in this PR. Push or merge separately.
- `crosscheck/docs/reports/crosscheck-critical-analysis-reassessment.md` and `crosscheck/docs/research/crosscheck-review-may-2026.md` were left untracked by Phase 0 and are out of scope per its handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)