### PR TITLE
refactor(crosscheck): move /rationale to hellebuyck + status flip

### DIFF
--- a/crosscheck/JOURNAL.md
+++ b/crosscheck/JOURNAL.md
@@ -4,6 +4,17 @@ Journal for the Crosscheck plugin. Decisions that affect skills, agents, the MCP
 
 ---
 
+## 2026-05-11 — /rationale Layer-4 docs cascade + status flip
+
+**Type:** propagated-discovery
+**Touches:** docs/specs/rationale-2026-05-11.md (status field), agents/byfuglien.md, agents/hellebuyck.md, docs/agents.md, docs/skills.md, docs/assurance-hierarchy.md
+**Why:** Downstream from the snapshot merged at 3da376d. The snapshot reassigned `/rationale` from byfuglien (Layers 1–3) to hellebuyck (Layer 4 — semi-formal rationales); the agent pages, skill catalogue, agent overview, and assurance-hierarchy mapping all still pointed the other way. Also flips the snapshot's frontmatter from `Status: Draft` to `Status: Snapshot` per v2 methodology (`docs/add/.retrospective/findings-and-methodology-v2.md:218-223`) — Status: Snapshot = committed, and merge is the ratification signal.
+**Links:** [snapshot](docs/specs/rationale-2026-05-11.md), [v2 methodology](docs/add/.retrospective/findings-and-methodology-v2.md), parent PR (#169)
+
+Single PR, low risk. `/rationale` removed from byfuglien's skill tables, classification, skill-readme list, and Phase 4 quality gates; added to hellebuyck's new "Adequacy (Layer 4 — semi-formal rationales)" subsection with matching classification, skill-readme entry, and validate-output gates (claim tree soundness, classification accuracy, actionable output). `docs/agents.md` moves `/rationale` from byfuglien's "Spec management" bullet to hellebuyck's "Layer 4 (impl–spec alignment)" bullet and rewords the handoff seam — the `/rationale` → `/spec-adversary` chain is now intra-hellebuyck rather than byfuglien→hellebuyck; the seam stands. `docs/skills.md` reflows the "Spec management & adequacy" section into "Spec management" (byfuglien) and folds `/rationale` into the existing "Layer 4 (impl–spec alignment, semi-formal rationales)" section. `docs/assurance-hierarchy.md` extends the Layer 4 row with `/rationale` and adds a "When to use what" pointer. Snapshot text is left untouched apart from the status flip — its byfuglien.md:147 cross-reference becomes stale, but the snapshot is a dated artefact (v2 §3.3); stale line numbers are expected, content stands. SKILL.md catch-up (C0 trust branch, FORMAL Layer 1 vs Layer 4 routing, STATIC citation post-process) ships separately per the snapshot's own callout.
+
+---
+
 ## 2026-05-11 — /rationale design-intent snapshot
 
 **Type:** propagated-discovery

--- a/crosscheck/agents/byfuglien.md
+++ b/crosscheck/agents/byfuglien.md
@@ -39,12 +39,6 @@ Orchestrator for formal verification and semi-formal code reasoning. Named after
 | `/correspondence-review` | Classify each Lean def vs source as exact / abstraction / approximation / mismatch (step 4) |
 | `/drt-oracle` | Differential random testing between the Lean model and production code (step 5) |
 
-### Bridging Formal and Semi-formal
-
-| Skill | What it does |
-|-------|-------------|
-| `/rationale` | Build a hierarchical adequacy argument with mixed verification methods |
-
 ### Semi-formal Reasoning (evidence-grounded analysis)
 
 | Skill | What it does |
@@ -72,7 +66,7 @@ Classify the user's request to determine which skill to invoke.
 | Test strength | "Is this test too weak?", "Run mutation probe", "Check test adequacy" (rotation-based) | `/assurance-probe` |
 | Lean pipeline (per-module model + DRT) | "Build a Lean model", "DRT this module", "fuzz against the lean spec", hand- or AI-written code with provable properties and a tractable input space | Pipeline: `/informal-spec` → `/lean-spec` → `/lean-impl` → `/correspondence-review` → `/drt-oracle` |
 | Lean pipeline — single step | "informal spec", "lean spec stub", "lean impl", "correspondence review", "drt" | The named step only; check upstream artefacts exist first |
-| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | Hand to hellebuyck: `/rationale` (Layer 4 — semi-formal rationales) |
 | Code questions | "What does X do?", "Is there a difference?", "Do we need this?" | `/reason` |
 | Patch comparison | Two diffs, two patches, "compare these changes" | `/compare-patches` |
 | Bug/fault finding | "Why does this fail?", stack traces, unexpected behavior | `/locate-fault` |
@@ -120,7 +114,6 @@ Read the selected skill's SKILL.md file and follow its methodology exactly:
 - For `/lean-impl`: read `skills/lean-impl/SKILL.md`
 - For `/correspondence-review`: read `skills/correspondence-review/SKILL.md`
 - For `/drt-oracle`: read `skills/drt-oracle/SKILL.md`
-- For `/rationale`: read `skills/rationale/SKILL.md`
 - For `/assurance-probe`: read `skills/assurance-probe/SKILL.md`
 - For `/reason`: read `skills/reason/SKILL.md`
 - For `/compare-patches`: read `skills/compare-patches/SKILL.md`
@@ -141,12 +134,10 @@ Every result must pass these quality gates before delivery:
 - Clean output with no `_dafny.` references remaining
 - Difficulty metrics reviewed (flag trivial proofs, high resource usage)
 
-**For spec management and adequacy output (`/check-regressions`, `/suggest-specs`, `/rationale`):**
+**For spec management output (`/check-regressions`, `/suggest-specs`):**
 - **Registry consistency** — `/check-regressions` results match the current state of `.crosscheck/specs.json`
 - **Proposal quality** — `/suggest-specs` proposals are grounded in actual code patterns, not generic suggestions
-- **Claim tree soundness** — `/rationale` tree structure is valid: if all leaves hold, the root holds
-- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
-- **Actionable output** — every proposal or claim has a clear next step (skill to run, test to execute, or judgment to make)
+- **Actionable output** — every proposal has a clear next step (skill to run, test to execute, or judgment to make)
 
 **For semi-formal reasoning output:**
 - **Certificate completeness** — all required sections present and filled in

--- a/crosscheck/agents/hellebuyck.md
+++ b/crosscheck/agents/hellebuyck.md
@@ -47,6 +47,12 @@ Orchestrator for specification-chain assurance and governance scaffolding. Named
 |-------|-------------|
 | `/protected-surface-amend` | Given a planned change to a protected file, generate the governance-note amendment block (rationale, authority, linked roadmap item, diff plan) |
 
+### Adequacy (Layer 4 — semi-formal rationales)
+
+| Skill | What it does |
+|-------|-------------|
+| `/rationale` | Build a hierarchical claim tree arguing code is adequate; leaves tagged FORMAL / BEHAVIORAL / STATIC / SEMANTIC and discharged per class |
+
 ## Task Classification
 
 Classify the user's request to determine which skill to invoke. The spec chain degrades from deterministic (Layer 4, Dafny-backed — that's byfuglien's territory) to probabilistic (Layer 5, `/intent-check`) to best-effort (Layer 6, `/spec-adversary`). Bootstrap tasks precede verification tasks; status tasks require onboarding to be complete.
@@ -62,6 +68,7 @@ Classify the user's request to determine which skill to invoke. The spec chain d
 | Spec-intent alignment (Layer 5) | Protected-surface PR, "does the spec match the code", "run intent-check" | `/intent-check` |
 | Spec completeness (Layer 6) | "What are we missing?", "adversarial invariants", quarterly module review | `/spec-adversary` |
 | Governance amendment | Planned change to a protected file, "amendment block", "authority for this edit" | `/protected-surface-amend` |
+| Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
 | Implementation chain (hand down) | Module turns out to be a Dafny candidate, pure sequential logic, quantified properties | Hand to byfuglien: `/spec-iterate` → `/generate-verified` → `/extract-code` |
 | Proof exists but intent uncertain (escalate up) | byfuglien produced a clean proof; user asks "is the spec capturing intent?" | `/intent-check` (hellebuyck owns this; byfuglien escalates up) |
 | Code reasoning, fault-finding, patches | "Why does this fail?", "what does X do?", patch comparison | Hand to byfuglien: `/reason`, `/locate-fault`, `/compare-patches`, `/trace-execution` |
@@ -107,6 +114,7 @@ Read the selected skill's SKILL.md file and follow its methodology exactly:
 - For `/spec-adversary`: read `skills/spec-adversary/SKILL.md`
 - For `/acceptance-oracle-draft`: read `skills/acceptance-oracle-draft/SKILL.md`
 - For `/protected-surface-amend`: read `skills/protected-surface-amend/SKILL.md`
+- For `/rationale`: read `skills/rationale/SKILL.md`
 
 For the new-repo onboarding sequence (`/assurance-layer-audit` → `/assurance-init` → `/invariant-coverage-scaffold`), execute the skills sequentially, getting user approval between phases. Do not batch-run them — the audit's output informs init's scaffolding choices, and init's output informs which modules get coverage first.
 
@@ -143,6 +151,11 @@ Every result must pass these quality gates before delivery:
 - **Amendment block complete** — rationale, authority, linked roadmap item, diff plan all present
 - **Partition-aware** — amendment cites which class (Harness/workflow vs Module invariants/tests) the touched file belongs to
 - **Authority cited** — authority line names a ROADMAP item, prior attestation, or human decision, not "agent judgement"
+
+**For adequacy output (`/rationale`):**
+- **Claim tree soundness** — tree structure is valid: if all leaves hold, the root holds (structural check; does not catch missing branches — see `../docs/specs/rationale-2026-05-11.md` §7–§8)
+- **Classification accuracy** — leaf claims tagged with the correct verification method (`[FORMAL]`/`[BEHAVIORAL]`/`[STATIC]`/`[SEMANTIC]`)
+- **Actionable output** — every claim has a clear next step (skill to run, test to execute, or judgment to make)
 
 **For all output:**
 - **Verification checklist present** — output includes a Verification Checklist section with all bracketed items filled in from the analysis

--- a/crosscheck/docs/agents.md
+++ b/crosscheck/docs/agents.md
@@ -10,7 +10,7 @@ Crosscheck ships two complementary orchestrators, both named after Winnipeg Jets
 
 - Formal verification: [`/spec-iterate`](../skills/spec-iterate/SKILL.md), [`/generate-verified`](../skills/generate-verified/SKILL.md), [`/extract-code`](../skills/extract-code/SKILL.md), [`/lightweight-verify`](../skills/lightweight-verify/SKILL.md)
 - Semi-formal reasoning: [`/reason`](../skills/reason/SKILL.md), [`/compare-patches`](../skills/compare-patches/SKILL.md), [`/locate-fault`](../skills/locate-fault/SKILL.md), [`/trace-execution`](../skills/trace-execution/SKILL.md)
-- Spec management: [`/check-regressions`](../skills/check-regressions/SKILL.md), [`/suggest-specs`](../skills/suggest-specs/SKILL.md), [`/rationale`](../skills/rationale/SKILL.md)
+- Spec management: [`/check-regressions`](../skills/check-regressions/SKILL.md), [`/suggest-specs`](../skills/suggest-specs/SKILL.md)
 
 **When to invoke.** "I want to verify this code." "Is this patch equivalent to the old one?" "Why does this test fail?" "What does this function do?"
 
@@ -21,7 +21,7 @@ Crosscheck ships two complementary orchestrators, both named after Winnipeg Jets
 **Skills it routes to.**
 
 - Onboarding & status: [`/assurance-layer-audit`](../skills/assurance-layer-audit/SKILL.md), [`/assurance-init`](../skills/assurance-init/SKILL.md), [`/assurance-status`](../skills/assurance-status/SKILL.md), [`/assurance-roadmap-check`](../skills/assurance-roadmap-check/SKILL.md)
-- Layer 4 (impl–spec alignment): [`/invariant-coverage-scaffold`](../skills/invariant-coverage-scaffold/SKILL.md), [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md)
+- Layer 4 (impl–spec alignment): [`/invariant-coverage-scaffold`](../skills/invariant-coverage-scaffold/SKILL.md), [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md), [`/rationale`](../skills/rationale/SKILL.md) (semi-formal rationales — see [snapshot](./specs/rationale-2026-05-11.md))
 - Layer 5 (spec–intent alignment): [`/intent-check`](../skills/intent-check/SKILL.md), [`/acceptance-oracle-draft`](../skills/acceptance-oracle-draft/SKILL.md)
 - Layer 6 (spec completeness): [`/spec-adversary`](../skills/spec-adversary/SKILL.md)
 
@@ -32,7 +32,7 @@ Crosscheck ships two complementary orchestrators, both named after Winnipeg Jets
 Byfuglien proves the code is correct against the spec. Hellebuyck checks the spec is the right spec and that the spec→test→code chain stays mechanically enforced. Concrete escalation patterns:
 
 - Byfuglien proves your sort is correct — hellebuyck's [`/intent-check`](../skills/intent-check/SKILL.md) confirms the spec actually says "sorted permutation" and not just "monotonically increasing".
-- Byfuglien's [`/rationale`](../skills/rationale/SKILL.md) produces an adequacy argument for a CRUD endpoint — hellebuyck's [`/spec-adversary`](../skills/spec-adversary/SKILL.md) probes for missing invariants the rationale didn't anticipate.
+- Byfuglien handles a CRUD endpoint's code reasoning — hellebuyck's [`/rationale`](../skills/rationale/SKILL.md) builds the adequacy argument, and [`/spec-adversary`](../skills/spec-adversary/SKILL.md) probes for missing invariants the rationale didn't anticipate.
 - A protected-surface file is about to change — use byfuglien for code reasoning about the diff, then hellebuyck's [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md) to generate the governance note that ships in the same PR.
 
 ## Invocation

--- a/crosscheck/docs/assurance-hierarchy.md
+++ b/crosscheck/docs/assurance-hierarchy.md
@@ -11,7 +11,7 @@ Crosscheck organises correctness into six layers of assurance. Layers 1–3 prov
 | 1 | Formally verified pure code | [`/spec-iterate`](../skills/spec-iterate/SKILL.md), [`/generate-verified`](../skills/generate-verified/SKILL.md), [`/extract-code`](../skills/extract-code/SKILL.md), [`/lightweight-verify`](../skills/lightweight-verify/SKILL.md) | Deterministic | byfuglien |
 | 2 | Compilation correctness | (Not addressed — trust your toolchain) | n/a | n/a |
 | 3 | Contract graph verification | (Future — see research doc) | n/a | n/a |
-| 4 | Implementation–spec alignment | [`/invariant-coverage-scaffold`](../skills/invariant-coverage-scaffold/SKILL.md), [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md), [`/check-regressions`](../skills/check-regressions/SKILL.md), [`/assurance-probe`](../skills/assurance-probe/SKILL.md) (Phase 1 – experimental; gates on SNR ≥ 1:3 over 20 runs) | Deterministic | hellebuyck (4) / byfuglien (regressions) |
+| 4 | Implementation–spec alignment + semi-formal rationales | [`/invariant-coverage-scaffold`](../skills/invariant-coverage-scaffold/SKILL.md), [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md), [`/rationale`](../skills/rationale/SKILL.md) (see [snapshot](./specs/rationale-2026-05-11.md)), [`/check-regressions`](../skills/check-regressions/SKILL.md), [`/assurance-probe`](../skills/assurance-probe/SKILL.md) (Phase 1 – experimental; gates on SNR ≥ 1:3 over 20 runs) | Deterministic (4); semi-formal (rationales) | hellebuyck (4 + rationales) / byfuglien (regressions, probe) |
 | 5 | Specification–intent alignment | [`/intent-check`](../skills/intent-check/SKILL.md), [`/acceptance-oracle-draft`](../skills/acceptance-oracle-draft/SKILL.md) | Probabilistic (~96%) | hellebuyck |
 | 6 | Specification completeness | [`/spec-adversary`](../skills/spec-adversary/SKILL.md) | Best-effort | hellebuyck |
 
@@ -29,6 +29,7 @@ Crosscheck organises correctness into six layers of assurance. Layers 1–3 prov
 
 - Writing new business logic that should be provably correct? → [`/spec-iterate`](../skills/spec-iterate/SKILL.md) → [`/generate-verified`](../skills/generate-verified/SKILL.md) → [`/extract-code`](../skills/extract-code/SKILL.md) (byfuglien).
 - Code is correct but you suspect the spec might be wrong? → [`/intent-check`](../skills/intent-check/SKILL.md) (hellebuyck).
+- Code mixes provable, testable, readable, and judgement claims and you want one structured argument? → [`/rationale`](../skills/rationale/SKILL.md) (hellebuyck — Layer 4 semi-formal rationales).
 - Adding a new feature with user-observable behaviour? → [`/acceptance-oracle-draft`](../skills/acceptance-oracle-draft/SKILL.md) to lock down the scenarios upfront (hellebuyck).
 - Changing a file that's already governed (e.g. an invariant doc, an agent, a workflow)? → [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md) (hellebuyck).
 - Module has been stable for a while — what might its spec be missing? → [`/spec-adversary`](../skills/spec-adversary/SKILL.md) (hellebuyck).

--- a/crosscheck/docs/skills.md
+++ b/crosscheck/docs/skills.md
@@ -33,20 +33,20 @@ The five-step Lean pipeline. Run sequentially; each consumes the previous step's
 | [`/locate-fault`](../skills/locate-fault/SKILL.md) | "locate fault", "find the bug", "why does this fail", "root cause" | Locate the root cause of a failing test using 4-phase structured analysis. | byfuglien |
 | [`/trace-execution`](../skills/trace-execution/SKILL.md) | "trace execution", "what happens when", "follow the code path", "call graph" | Hypothesis-driven execution-path tracing that builds complete call graphs. | byfuglien |
 
-## Spec management & adequacy
+## Spec management
 
 | Skill | Trigger phrases | One-line summary | Owner |
 |-------|----------------|------------------|-------|
 | [`/check-regressions`](../skills/check-regressions/SKILL.md) | "check regressions", "did my changes break specs", "re-verify" | Re-verify Dafny specs whose source files have changed. | byfuglien |
 | [`/suggest-specs`](../skills/suggest-specs/SKILL.md) | "suggest specs", "what should I verify", "find verification targets" | Analyse code to propose candidate formal specifications. | byfuglien |
-| [`/rationale`](../skills/rationale/SKILL.md) | "build rationale", "is this code adequate", "adequacy argument" | Build a hierarchical claim tree arguing code adequately satisfies its requirements. | byfuglien |
 
-## Assurance hierarchy — Layer 4 (impl–spec alignment)
+## Assurance hierarchy — Layer 4 (impl–spec alignment, semi-formal rationales)
 
 | Skill | Trigger phrases | One-line summary | Owner |
 |-------|----------------|------------------|-------|
 | [`/invariant-coverage-scaffold`](../skills/invariant-coverage-scaffold/SKILL.md) | "invariant coverage", "coverage gate", "scaffold invariant check" | Generate a pre-commit + CI gate linking invariant docs to property tests (Go/Python/TypeScript in v1). | hellebuyck |
 | [`/protected-surface-amend`](../skills/protected-surface-amend/SKILL.md) | "amend protected file", "protected surface amendment", "governance note" | Generate the governance-note amendment block required when editing a protected-surface file. | hellebuyck |
+| [`/rationale`](../skills/rationale/SKILL.md) | "build rationale", "is this code adequate", "adequacy argument" | Build a hierarchical claim tree arguing code adequately satisfies its requirements; leaves classified by verification method. See [snapshot](./specs/rationale-2026-05-11.md). | hellebuyck |
 
 ## Assurance hierarchy — Layer 5 (spec–intent alignment)
 

--- a/crosscheck/docs/specs/rationale-2026-05-11.md
+++ b/crosscheck/docs/specs/rationale-2026-05-11.md
@@ -1,6 +1,6 @@
 ---
 Date: 2026-05-11
-Status: Draft
+Status: Snapshot
 Layer: 4 (semi-formal rationales) of the 6-layer assurance hierarchy
 Owner: hellebuyck
 Audience: Harry (red-pen). The operational prompt for the agent lives in `../../skills/rationale/SKILL.md`; this doc is the design intent behind that prompt.


### PR DESCRIPTION
## Summary

Downstream cascade from the `/rationale` design-intent snapshot merged at 3da376d (#169). Two coordinated moves:

- **Status flip.** `crosscheck/docs/specs/rationale-2026-05-11.md`: `Status: Draft` → `Status: Snapshot`. Per v2 methodology (`docs/add/.retrospective/findings-and-methodology-v2.md:218-223`), `Status: Snapshot` means *committed* — and PR merge *is* ratification. The snapshot landed at #169 with `Draft` still in the front-matter; this corrects the drift on the first snapshot rather than letting it set a precedent.
- **Layer-4 reassignment.** `/rationale` moves from byfuglien to hellebuyck across the five files the snapshot called out:
  - `crosscheck/agents/byfuglien.md` — dropped from the Bridging table, the Adequacy-argument classification row, the skill-readme list, and the Phase 4 spec-management gates.
  - `crosscheck/agents/hellebuyck.md` — added in a new *Adequacy (Layer 4 — semi-formal rationales)* subsection with matching classification, skill-readme entry, and validate-output gates (claim tree soundness, classification accuracy, actionable output).
  - `crosscheck/docs/agents.md` — bullet moved between agents; handoff seam reworded (`/rationale` → `/spec-adversary` is now intra-hellebuyck).
  - `crosscheck/docs/skills.md` — `/rationale` folded into the existing Layer 4 section; old "Spec management & adequacy" header renamed to "Spec management" (the remaining byfuglien skills).
  - `crosscheck/docs/assurance-hierarchy.md` — Layer 4 row extended; "When to use what" pointer added.

## Out of scope

- **SKILL.md catch-up.** The snapshot calls out three SKILL.md changes (C0 trust-boundary top-level branch; FORMAL routing Layer 1 vs Layer 4; STATIC citation deterministic post-process). Those land in separate PRs.
- **Snapshot internals.** The snapshot file is otherwise untouched — only the `Status:` field changed. Its `byfuglien.md:147` cross-reference becomes stale, which is expected for dated artefacts (v2 §3.3 — snapshots aren't re-ratified).

## Test plan

- [ ] No remaining `/rationale` references on byfuglien (verify with `grep -n 'rationale' crosscheck/agents/byfuglien.md`)
- [ ] `/rationale` appears on hellebuyck under Adequacy, with classification row, skill-readme entry, and Phase 4 gates
- [ ] `docs/skills.md` Layer 4 section lists `/rationale` with `hellebuyck` owner
- [ ] `docs/assurance-hierarchy.md` Layer 4 row lists `/rationale`
- [ ] `docs/agents.md` seam bullet reads as intra-hellebuyck (rationale + spec-adversary)
- [ ] Journal entry present in `crosscheck/JOURNAL.md`
- [ ] Snapshot front-matter reads `Status: Snapshot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)