### PR TITLE
docs(crosscheck): defer /rationale STATIC citation post-process

### DIFF
--- a/crosscheck/JOURNAL.md
+++ b/crosscheck/JOURNAL.md
@@ -4,6 +4,17 @@ Journal for the Crosscheck plugin. Decisions that affect skills, agents, the MCP
 
 ---
 
+## 2026-05-11 — /rationale snapshot: defer STATIC citation post-process
+
+**Type:** correction
+**Touches:** docs/specs/rationale-2026-05-11.md (§4 STATIC, §8 deferred-until-field-evidence)
+**Why:** No fabricated `STATIC` citations observed in `/rationale` invocations to date. The snapshot's §4 declared the deterministic read-and-string-search post-process as part of the design; this is premature surface area against an unobserved failure mode. §8 already establishes the right pattern for this exact reflex — deferred until field evidence — applied there to tree completeness.
+**Links:** [snapshot](docs/specs/rationale-2026-05-11.md), parent snapshot PR (#169), cascade PR (#170)
+
+The §4 STATIC paragraph drops the post-process language and adds a one-line pointer to §8. §8 gains a second deferred concern ("STATIC citation honesty") with the same shape as the existing tree-completeness block — observed-failure trigger, on-shelf option (read-and-string-search), explicit cost framing. Strict v2 reading would make this a new dated snapshot superseding 2026-05-11; chose the lighter-touch amendment within the same week as merge, since this is correction of premature scope rather than design evolution. Downstream effect: the planned SKILL.md catch-up PR series drops from three to two (C0 trust-boundary branch and FORMAL Layer 1 vs Layer 4 routing remain).
+
+---
+
 ## 2026-05-11 — /rationale Layer-4 docs cascade + status flip
 
 **Type:** propagated-discovery

--- a/crosscheck/docs/specs/rationale-2026-05-11.md
+++ b/crosscheck/docs/specs/rationale-2026-05-11.md
@@ -70,9 +70,7 @@ The skill picks the route by asking whether the leaf names a property of pure co
 
 **BEHAVIORAL.** The skill generates test code (concrete cases or property-based) and presents it. It does not run the tests. Marking is *"tests generated — run to verify."*
 
-**STATIC.** The skill reads the code and cites a specific `file:line` range as evidence. Example from `../../skills/rationale/SKILL.md:108`: *"C1.2 verified — all required fields set at `model.py:42-48`."*
-
-A fast deterministic post-process reads each cited range and checks that the keywords from the claim text appear there (or that the cited identifier is defined within the range). Citations failing the check are returned for re-citation or downgraded to SEMANTIC for human review. The check runs without an LLM in the loop — a pure read-and-string-search pass. This catches fabricated citations without relying on the agent to be honest about them.
+**STATIC.** The skill reads the code and cites a specific `file:line` range as evidence. Example from `../../skills/rationale/SKILL.md:108`: *"C1.2 verified — all required fields set at `model.py:42-48`."* No automated check on the citation in this snapshot — the agent's read-and-cite pass is trusted; fabricated-citation handling is deferred until field evidence (see §8).
 
 **SEMANTIC.** The skill states what the human must judge and provides the relevant code context. Marking is *"human review required."*
 
@@ -115,9 +113,17 @@ The shape is borrowed wholesale from the Goal Structuring Notation tradition: th
 
 Trigger to revisit: field reports of `/rationale` invocations where the agent built a sound tree but the user noticed (or was bitten by) a missing branch.
 
+**STATIC citation honesty.** The agent's `file:line` citation is trusted on its face — there is no automated check that the keywords from the claim text actually appear in the cited range, or that the identifier the citation names is defined inside it. A fabricated or sloppy citation (the agent points at a plausible-looking range that doesn't actually contain the evidence) would silently mark a STATIC leaf as verified.
+
+**Deferred.** No citation check is added in this snapshot. Fabricated citations have not been observed in `/rationale` invocations so far; building a deterministic gate against an unobserved failure mode is the same premature-surface-area trap §8 already flags for tree completeness. If invocations start showing fabricated or sloppy citations, the shelf option is:
+
+- *Read-and-string-search post-process* — for each cited range, read the file slice and check that the claim's keywords appear there (or that the cited identifier is defined inside). Failures return for re-citation or downgrade to SEMANTIC. No LLM in the loop. Cost: small, but only earns its place once the failure mode is real.
+
+Trigger to revisit: a field report (or a `/rationale` invocation surfaced in orchestrator audit) where a STATIC leaf was marked verified against a citation that did not actually contain the evidence.
+
 ## 9. Verification approach for this spec
 
-This spec describes prompt content in `../../skills/rationale/SKILL.md`. There is no executable model to verify against. The acceptance criterion is behavioural: a user invokes `/rationale` on a real function and gets a claim tree with a `C0` trust-boundary branch, classified leaves, attempts at verification per class (Dafny for Layer 1 FORMAL, the Lean pipeline for Layer 4 FORMAL, deterministic citation-checked STATIC, generated BEHAVIORAL test code, human-prompt SEMANTIC), and a traceable checklist whose summary table balances. Validation is by direct use, not by a separate verification pipeline.
+This spec describes prompt content in `../../skills/rationale/SKILL.md`. There is no executable model to verify against. The acceptance criterion is behavioural: a user invokes `/rationale` on a real function and gets a claim tree with a `C0` trust-boundary branch, classified leaves, attempts at verification per class (Dafny for Layer 1 FORMAL, the Lean pipeline for Layer 4 FORMAL, `file:line`-cited STATIC, generated BEHAVIORAL test code, human-prompt SEMANTIC), and a traceable checklist whose summary table balances. Validation is by direct use, not by a separate verification pipeline.
 
 The orchestrator's existing soundness check stays in place: *"`/rationale` tree structure is valid: if all leaves hold, the root holds"* (`../../agents/byfuglien.md:147`). That check is structural — it does not catch missing branches; see §7 non-goal and the deferred handling in §8.
 


### PR DESCRIPTION
## Summary

Snapshot amendment. Moves the deterministic citation post-process out of `/rationale`'s declared design (§4) and into the deferred-until-field-evidence section (§8), alongside the existing tree-completeness deferral.

**Why now.** No fabricated `STATIC` citations have been observed in `/rationale` invocations to date. The snapshot's §4 declared the post-process as design; building a deterministic gate against an unobserved failure mode is premature surface area. §8 already encodes the right reflex for this exact case (deferred until field evidence) — applying it to STATIC keeps the pattern consistent rather than scattering scope decisions.

**v2 framing.** Strict v2 reading would have this be a new dated snapshot superseding 2026-05-11 (specs are frozen, design changes get new snapshots). Took the lighter-touch amendment within the same week as merge — this is correction of premature scope rather than design evolution. Recorded in the journal entry alongside that reasoning.

## Edits

- **§4 STATIC** (lines 73–75 → 1 line): drops the post-process language; replaces with a one-line pointer to §8.
- **§8 deferred-until-field-evidence**: gains a second deferred concern ("STATIC citation honesty") with the same shape as the tree-completeness block — observed-failure trigger, on-shelf option (read-and-string-search post-process), explicit cost framing.
- **§9 acceptance criterion**: replaces "deterministic citation-checked STATIC" with "\`file:line\`-cited STATIC".
- **JOURNAL.md**: new entry recording the amendment + reasoning.

## Downstream effect

Planned SKILL.md catch-up series drops from three PRs to two:
- ~~#2C STATIC citation deterministic post-process~~ — cancelled
- #2A C0 trust-boundary top-level branch — unchanged
- #2B FORMAL routing Layer 1 vs Layer 4 — unchanged

## Test plan

- [ ] §4 STATIC reads as one paragraph, no post-process language, points to §8
- [ ] §8 has a \"STATIC citation honesty\" block matching the shape of the tree-completeness block above it
- [ ] §9 acceptance criterion no longer claims deterministic citation-checking
- [ ] Journal entry present in \`crosscheck/JOURNAL.md\`, type \`correction\`, links to snapshot and parent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)