### PR TITLE
fix(claude-github-app): use Basic auth for git smart-HTTP

### DIFF
--- a/tools/claude-github-app/cmd/git/main_test.go
+++ b/tools/claude-github-app/cmd/git/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,13 @@ import (
 	"github.com/nicholls-inc/claude-code-marketplace/tools/claude-github-app/internal/config"
 	"github.com/nicholls-inc/claude-code-marketplace/tools/claude-github-app/internal/token"
 )
+
+// wantBasicHeader mirrors the launcher-package helper so tests assert against
+// the exact wire string the renderer will emit.
+func wantBasicHeader(token string) string {
+	creds := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+	return "Authorization: Basic " + creds
+}
 
 func TestInjectGitAuth_WritesPerAppConfigAndReturnsEnv(t *testing.T) {
 	tmpHome := t.TempDir()
@@ -49,7 +57,7 @@ func TestInjectGitAuth_WritesPerAppConfigAndReturnsEnv(t *testing.T) {
 	data, _ := os.ReadFile(wantPath)
 	contents := string(data)
 	for _, want := range []string{
-		"Authorization: Bearer ghs_abc",
+		wantBasicHeader("ghs_abc"),
 		"name = my-app[bot]",
 		"email = 42+my-app[bot]@users.noreply.github.com",
 	} {
@@ -96,10 +104,10 @@ func TestInjectGitAuth_RewritesOnSecondCall(t *testing.T) {
 	}
 	wantPath := filepath.Join(tmpHome, ".cache", "claude-github-app", "r-app-gitconfig")
 	data, _ := os.ReadFile(wantPath)
-	if strings.Contains(string(data), "Bearer first") {
+	if strings.Contains(string(data), wantBasicHeader("first")) {
 		t.Errorf("stale token still present after refresh:\n%s", string(data))
 	}
-	if !strings.Contains(string(data), "Bearer second") {
+	if !strings.Contains(string(data), wantBasicHeader("second")) {
 		t.Errorf("new token not written:\n%s", string(data))
 	}
 }

--- a/tools/claude-github-app/internal/launcher/exec_test.go
+++ b/tools/claude-github-app/internal/launcher/exec_test.go
@@ -1,14 +1,24 @@
 package launcher
 
 import (
+	"encoding/base64"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 )
+
+// wantBasicHeader returns the literal "Authorization: Basic <base64(x-access-token:token)>"
+// string the renderer should emit for token. Used so assertions read like
+// `Contains(contents, wantBasicHeader("ghs_test"))` instead of inlining base64.
+func wantBasicHeader(token string) string {
+	creds := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
+	return "Authorization: Basic " + creds
+}
 
 func stubPath(t *testing.T) string {
 	t.Helper()
@@ -186,7 +196,7 @@ func TestTempGitConfig_ContentsAndMode(t *testing.T) {
 		"name = my-app[bot]",
 		"email = 42+my-app[bot]@users.noreply.github.com",
 		"helper =",
-		"extraHeader = Authorization: Bearer ghs_test",
+		"extraHeader = " + wantBasicHeader("ghs_test"),
 	} {
 		if !strings.Contains(contents, want) {
 			t.Errorf("git config missing %q\ngot:\n%s", want, contents)
@@ -204,8 +214,8 @@ func TestTempGitConfig_NoBotIdentity(t *testing.T) {
 	if strings.Contains(string(data), "[user]") {
 		t.Errorf("[user] block leaked despite no bot identity: %s", string(data))
 	}
-	if !strings.Contains(string(data), "Authorization: Bearer ghs_test") {
-		t.Errorf("auth header missing")
+	if !strings.Contains(string(data), wantBasicHeader("ghs_test")) {
+		t.Errorf("auth header missing:\n%s", string(data))
 	}
 }
 
@@ -223,8 +233,46 @@ func TestRenderGitConfig_OmitsUserBlockWhenIdentityMissing(t *testing.T) {
 	if strings.Contains(s, "[user]") {
 		t.Errorf("expected no [user] block, got:\n%s", s)
 	}
-	if !strings.Contains(s, "Authorization: Bearer x") {
+	if !strings.Contains(s, wantBasicHeader("x")) {
 		t.Errorf("auth header missing:\n%s", s)
+	}
+}
+
+// TestRenderGitConfig_UsesBasicXAccessToken locks the wire format the renderer
+// must emit. GitHub's git smart-HTTP transport rejects `Authorization: Bearer`
+// with HTTP 401; only `Authorization: Basic base64("x-access-token:<token>")`
+// is accepted on /info/refs and /git-{upload,receive}-pack. Any future drift
+// back to Bearer, accidental URL-safe base64, or stripped padding fails this
+// test with a meaningful message.
+func TestRenderGitConfig_UsesBasicXAccessToken(t *testing.T) {
+	const token = "ghs_RegressionTestToken_0123"
+	s, err := RenderGitConfig(GitConfigOpts{Token: token})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Match the non-empty extraHeader line; the empty-reset line above it
+	// must not be picked up.
+	re := regexp.MustCompile(`(?m)^\textraHeader = (\S.*)$`)
+	matches := re.FindStringSubmatch(s)
+	if matches == nil {
+		t.Fatalf("non-empty extraHeader line not found in:\n%s", s)
+	}
+	header := matches[1]
+
+	const prefix = "Authorization: Basic "
+	if !strings.HasPrefix(header, prefix) {
+		t.Fatalf("extraHeader scheme = %q, want prefix %q (Bearer is rejected by git smart-HTTP)", header, prefix)
+	}
+	encoded := strings.TrimPrefix(header, prefix)
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("base64 decode of %q failed: %v (must use StdEncoding with padding)", encoded, err)
+	}
+	want := "x-access-token:" + token
+	if string(decoded) != want {
+		t.Fatalf("decoded credentials = %q, want %q", string(decoded), want)
 	}
 }
 
@@ -254,7 +302,7 @@ func TestWriteGitConfigAtomic_CreatesFileWithModeAndContents(t *testing.T) {
 	}
 	data, _ := os.ReadFile(dst)
 	contents := string(data)
-	if !strings.Contains(contents, "Authorization: Bearer ghs_abc") {
+	if !strings.Contains(contents, wantBasicHeader("ghs_abc")) {
 		t.Errorf("auth header missing:\n%s", contents)
 	}
 	if !strings.Contains(contents, "name = my-app[bot]") {
@@ -271,10 +319,12 @@ func TestWriteGitConfigAtomic_OverwritesExistingFile(t *testing.T) {
 		t.Fatal(err)
 	}
 	data, _ := os.ReadFile(dst)
-	if strings.Contains(string(data), "first") {
+	// Tokens appear inside the base64-encoded x-access-token:<token> payload, so
+	// match against the rendered Basic header rather than the bare token string.
+	if strings.Contains(string(data), wantBasicHeader("first")) {
 		t.Errorf("old token leaked:\n%s", string(data))
 	}
-	if !strings.Contains(string(data), "second") {
+	if !strings.Contains(string(data), wantBasicHeader("second")) {
 		t.Errorf("new token missing:\n%s", string(data))
 	}
 }

--- a/tools/claude-github-app/internal/launcher/gitconfig.go
+++ b/tools/claude-github-app/internal/launcher/gitconfig.go
@@ -1,6 +1,7 @@
 package launcher
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,7 +10,12 @@ import (
 
 // GitConfigOpts controls the contents of the temp GIT_CONFIG_GLOBAL file.
 type GitConfigOpts struct {
-	Token    string // required — Bearer token for http.extraHeader
+	// Token is required. It is the GitHub App installation token used as the
+	// password in HTTP Basic auth (username "x-access-token") for the
+	// http.extraHeader entry. GitHub's git smart-HTTP transport rejects
+	// Bearer auth on /info/refs and /git-{upload,receive}-pack with HTTP 401,
+	// even though the same token works as Bearer against api.github.com.
+	Token    string
 	BotName  string // optional — set [user] block when both BotName and BotEmail are set
 	BotEmail string
 }
@@ -28,10 +34,13 @@ func RenderGitConfig(opts GitConfigOpts) (string, error) {
 	}
 	// Clear any inherited credential helper so git doesn't reach for the keychain.
 	fmt.Fprintf(&b, "[credential]\n\thelper =\n")
-	// First extraHeader empty value clears any inherited header chain (defensive);
-	// second sets ours. git concatenates extraHeader values, so resetting first
-	// is the documented pattern.
-	fmt.Fprintf(&b, "[http]\n\textraHeader =\n\textraHeader = Authorization: Bearer %s\n", opts.Token)
+	// First extraHeader empty value clears any inherited header chain (defensive
+	// — git concatenates extraHeader multivar values, so resetting first prevents
+	// any system-level header from being appended alongside ours). Second sets
+	// our auth: Basic base64("x-access-token:<token>"). Bearer is rejected by
+	// git's smart-HTTP transport with 401 — see GitConfigOpts.Token doc.
+	creds := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + opts.Token))
+	fmt.Fprintf(&b, "[http]\n\textraHeader =\n\textraHeader = Authorization: Basic %s\n", creds)
 	return b.String(), nil
 }
 


### PR DESCRIPTION
## Summary

- Switch git shim's `http.extraHeader` from `Authorization: Bearer <token>` to `Authorization: Basic base64("x-access-token:<token>")`. Bearer is rejected by GitHub's git smart-HTTP endpoints with HTTP 401; only Basic with the `x-access-token` username is accepted for installation tokens.
- Add `TestRenderGitConfig_UsesBasicXAccessToken` that decodes the rendered header and asserts the exact wire format, locking against future regressions back to Bearer / URL-safe base64 / stripped padding.
- Update mechanical Bearer assertions in `exec_test.go` and `cmd/git/main_test.go` to use a `wantBasicHeader(token)` helper.

## Why this matters

Pre-fix, every `git push`/`git fetch`/`git ls-remote` through the wrapped shim failed with `fatal: could not read Username for 'https://github.com': terminal prompts disabled` (38 occurrences across recent agent sessions). Git received the Bearer header, GitHub returned 401, and git fell through the credential chain to a TTY prompt that does not exist in headless / agent sessions.

Proven against a live token this turn:

| | Endpoint | Bearer | Basic (x-access-token) |
|---|---|---|---|
| REST | `api.github.com/repos/...` | 200 | 200 |
| Git smart-HTTP | `github.com/.../info/refs?service=git-upload-pack` | **401** | 200 |

## Test plan

- [x] `cd tools/claude-github-app && go test ./... -race -count=1` — all packages pass, including the new regression test.
- [x] `make build-shims && make install-shims` — clean build.
- [x] End-to-end smoke from a mapped CWD: `~/bin/git ls-remote https://github.com/nicholls-inc/claude-code-marketplace.git HEAD` returns the HEAD SHA with exit 0 (was exit 128 with `could not read Username` pre-fix).
- [x] Inverse check: rewritten `~/.cache/claude-github-app/<app>-gitconfig` contains `Authorization: Basic <base64>`; `base64 -d` round-trips to `x-access-token:<token>`.

## Out of scope

This patch fixes the wrapper's correctness. Two adjacent issues identified during diagnosis are user-owned environment changes and not in this PR:

1. `~/bin` not on PATH in `~/.claude/settings.json` — without this, Claude Code sessions still bypass the (now-correct) shim entirely.
2. `~/.cache/claude-github-app` not in `sandbox.filesystem.allowWrite` — without this, sandboxed git invocations abort before reaching the renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)