### PR TITLE
feat(crosscheck): /audit-spec-coverage and /audit-invariant-consistency skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Crosscheck plugin. Crosschecks Claude's code claims using Dafny formal verificat
 - **Docker isolation**: Dafny 4.11.0 in a sandboxed container (no network, 512MB memory, 120s timeout); Lean 4 + Mathlib in a sister container with Mathlib oleans pre-warmed (no network, 2GB memory, 240s timeout)
 - **Formal verification skills** (`crosscheck/skills/`): `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`
 - **Lean executable-model + DRT-oracle pipeline** (`crosscheck/skills/`): `/informal-spec`, `/lean-spec`, `/lean-impl`, `/correspondence-review`, `/drt-oracle`
-- **Spec management & adequacy skills** (`crosscheck/skills/`): `/check-regressions`, `/suggest-specs`, `/rationale`
+- **Spec management & adequacy skills** (`crosscheck/skills/`): `/check-regressions`, `/suggest-specs`, `/rationale`, `/audit-spec-coverage`, `/audit-invariant-consistency`
 - **Semi-formal reasoning skills** (`crosscheck/skills/`): `/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution`
 - **Orchestrator agent** (`crosscheck/agents/byfuglien.md`): Unified task classification, skill routing, and output validation
 

--- a/crosscheck/README.md
+++ b/crosscheck/README.md
@@ -66,8 +66,8 @@ The split is principled in shape but **asymmetric in substance** — Byfuglien a
 | Byfuglien (impl chain) | Hellebuyck (spec chain) | Orthogonal: semi-formal reasoning |
 |---|---|---|
 | Layer 1 (Dafny): `/spec-iterate`, `/generate-verified`, `/extract-code`, `/lightweight-verify`, `/suggest-specs` | Layer 4 (alignment): `/invariant-coverage-scaffold`, `/protected-surface-amend` | `/reason` |
-| Layer 1 (Lean): `/informal-spec` → `/lean-spec` → `/lean-impl` → `/correspondence-review` → `/drt-oracle` | Layer 5: `/intent-check`, `/acceptance-oracle-draft` | `/compare-patches` |
-| Layer 4 (regression): `/check-regressions` | Layer 6: `/spec-adversary` | `/locate-fault` |
+| Layer 1 (Lean): `/informal-spec` → `/lean-spec` → `/lean-impl` → `/correspondence-review` → `/drt-oracle` | Layer 5: `/intent-check`, `/audit-invariant-consistency`, `/acceptance-oracle-draft` | `/compare-patches` |
+| Layer 4 (regression): `/check-regressions` | Layer 6: `/spec-adversary`, `/audit-spec-coverage` | `/locate-fault` |
 | Spec-management bridge: `/rationale` | Governance index: `/assurance-init`, `/assurance-layer-audit`, `/assurance-status`, `/assurance-roadmap-check` | `/trace-execution` |
 
 The four semi-formal reasoning skills are not part of the 6-layer hierarchy. They are evidence-grounded code-analysis tools adapted from Ugare & Chandra (2026) and live as a third axis — Byfuglien-routed because they reason about implementation, but layer-agnostic.

--- a/crosscheck/agents/hellebuyck.md
+++ b/crosscheck/agents/hellebuyck.md
@@ -40,6 +40,8 @@ Orchestrator for specification-chain assurance and governance scaffolding. Named
 |-------|-------------|
 | `/intent-check` | Layer 5 two-LLM round-trip informalization over (invariant prose, covering test, code diff); appends to FP-tracker CSV and emits a JSON attestation |
 | `/spec-adversary` | Layer 6 best-effort — propose up to 3 candidate invariants the spec is missing, formatted for accept/reject/defer triage |
+| `/audit-spec-coverage` | Layer 6 doc-wide — emit section→invariant and audit-finding-ID→invariant coverage matrices, cap output at 15 prioritised gaps with 4-path triage blocks |
+| `/audit-invariant-consistency` | Layer 5+6 hybrid — three passes (within-module, cross-module, invariant-vs-spec) emitting capped consistency findings with `Accept (amend spec)` as a first-class triage option |
 
 ### Governance
 
@@ -67,6 +69,8 @@ Classify the user's request to determine which skill to invoke. The spec chain d
 | Roadmap drift | "Are the docs accurate?", "ROADMAP check", Status field sanity | `/assurance-roadmap-check` |
 | Spec-intent alignment (Layer 5) | Protected-surface PR, "does the spec match the code", "run intent-check" | `/intent-check` |
 | Spec completeness (Layer 6) | "What are we missing?", "adversarial invariants", quarterly module review | `/spec-adversary` |
+| Spec coverage probe (Layer 6) | "spec coverage", "coverage matrix", "which spec sections lack invariants", "audit-finding coverage" | `/audit-spec-coverage` |
+| Invariant consistency audit (Layer 5+6) | "are these invariants consistent", "find contradictions", "consistency audit", "invariant contradictions" | `/audit-invariant-consistency` |
 | Governance amendment | Planned change to a protected file, "amendment block", "authority for this edit" | `/protected-surface-amend` |
 | Adequacy argument | "Is this code adequate?", "Build a rationale", code + informal requirements | `/rationale` |
 | Implementation chain (hand down) | Module turns out to be a Dafny candidate, pure sequential logic, quantified properties | Hand to byfuglien: `/spec-iterate` → `/generate-verified` → `/extract-code` |
@@ -112,6 +116,8 @@ Read the selected skill's SKILL.md file and follow its methodology exactly:
 - For `/invariant-coverage-scaffold`: read `skills/invariant-coverage-scaffold/SKILL.md`
 - For `/intent-check`: read `skills/intent-check/SKILL.md`
 - For `/spec-adversary`: read `skills/spec-adversary/SKILL.md`
+- For `/audit-spec-coverage`: read `skills/audit-spec-coverage/SKILL.md`
+- For `/audit-invariant-consistency`: read `skills/audit-invariant-consistency/SKILL.md`
 - For `/acceptance-oracle-draft`: read `skills/acceptance-oracle-draft/SKILL.md`
 - For `/protected-surface-amend`: read `skills/protected-surface-amend/SKILL.md`
 - For `/rationale`: read `skills/rationale/SKILL.md`
@@ -141,11 +147,13 @@ Every result must pass these quality gates before delivery:
 - **Drift grounded in evidence** — `/assurance-roadmap-check` cites the ROADMAP line + the contradicting repo artifact for each drift flag
 - **Kill-criterion awareness** — status output surfaces FP rate vs the configured kill criterion (default 30%, configurable via `CROSSCHECK_FP_TRIPPED_THRESHOLD`; see `/intent-check` Configuration) and any open kill-criterion triggers
 
-**For spec-chain verification output (`/intent-check`, `/spec-adversary`):**
+**For spec-chain verification output (`/intent-check`, `/spec-adversary`, `/audit-spec-coverage`, `/audit-invariant-consistency`):**
 - **Structural separation** — `/intent-check` uses two distinct model contexts (back-translator blind to original requirement, diff-checker compares)
 - **FP-tracker appended** — `/intent-check` writes a CSV row matching the FP-tracker schema documented in `../skills/intent-check/references/fp-tracker-schema.md` (`date,invariant_touched,phase_verdict,human_verdict`) and a JSON attestation with `protected_files / content_hash / verdict / checked_at / pipeline_output`
-- **Signal-to-noise** — `/spec-adversary` proposes ≤3 candidate invariants, each with accept/reject/defer radio formatting; avoid spraying low-value suggestions
-- **Best-effort honesty** — Layer 6 output is explicitly labelled best-effort; no false claim of completeness
+- **Signal-to-noise** — `/spec-adversary` proposes ≤3 candidate invariants; `/audit-spec-coverage` and `/audit-invariant-consistency` cap at ≤15 prioritised findings each. Avoid spraying low-value suggestions
+- **Paired evidence** — `/audit-spec-coverage` cites spec line ranges + invariant IDs; `/audit-invariant-consistency` cites paired file:line evidence (invariant ↔ invariant, or invariant ↔ spec) for every finding
+- **4-path triage** — `/audit-spec-coverage` and `/audit-invariant-consistency` emit a 4-path triage block per finding (`Accept (fix invariant)` / `Accept (amend spec via /protected-surface-amend)` / `Reject` / `Defer`), with the spec-amend path first-class — not buried
+- **Best-effort honesty** — Layer 6 output is explicitly labelled best-effort; every audit skill includes a "What this does NOT catch" section enumerating known blind spots; no false claim of completeness
 
 **For governance output (`/protected-surface-amend`):**
 - **Amendment block complete** — rationale, authority, linked roadmap item, diff plan all present

--- a/crosscheck/docs/skills.md
+++ b/crosscheck/docs/skills.md
@@ -1,6 +1,6 @@
 # Crosscheck Skill Catalogue
 
-Exhaustive index of all 27 skills in the crosscheck plugin, grouped by category. See [`../README.md`](../README.md) for the plugin overview, and [`./agents.md`](./agents.md) for the orchestrator agent pages (`byfuglien`, `hellebuyck`).
+Exhaustive index of all 29 skills in the crosscheck plugin, grouped by category. See [`../README.md`](../README.md) for the plugin overview, and [`./agents.md`](./agents.md) for the orchestrator agent pages (`byfuglien`, `hellebuyck`).
 
 ## Formal verification (Dafny verify-and-extract)
 
@@ -53,6 +53,7 @@ The five-step Lean pipeline. Run sequentially; each consumes the previous step's
 | Skill | Trigger phrases | One-line summary | Owner |
 |-------|----------------|------------------|-------|
 | [`/intent-check`](../skills/intent-check/SKILL.md) | "intent check", "round-trip check", "spec-intent alignment" | Round-trip informalisation over (invariant prose, covering test, code diff) with FP tracking and a configurable kill criterion (default 30%, see SKILL Configuration). | hellebuyck |
+| [`/audit-invariant-consistency`](../skills/audit-invariant-consistency/SKILL.md) | "are these invariants consistent", "find contradictions", "consistency audit", "invariant contradictions" | Layer 5+6 hybrid — within-module + cross-module + invariant-vs-spec consistency passes. Doc-wide pre-test probe; distinct from `/intent-check`'s single-invariant post-test probe. | hellebuyck |
 | [`/acceptance-oracle-draft`](../skills/acceptance-oracle-draft/SKILL.md) | "acceptance oracle", "draft scenarios", "user-observable flows" | Draft mechanically-verifiable user-flow acceptance scenarios; rejects subjective criteria. | hellebuyck |
 
 ## Assurance hierarchy — Layer 6 (spec completeness)
@@ -60,6 +61,7 @@ The five-step Lean pipeline. Run sequentially; each consumes the previous step's
 | Skill | Trigger phrases | One-line summary | Owner |
 |-------|----------------|------------------|-------|
 | [`/spec-adversary`](../skills/spec-adversary/SKILL.md) | "spec adversary", "what is the spec missing", "propose missing invariants" | Adversarially probe a module's invariant docs for properties the spec is failing to capture. | hellebuyck |
+| [`/audit-spec-coverage`](../skills/audit-spec-coverage/SKILL.md) | "spec coverage", "coverage matrix", "which spec sections lack invariants", "audit-finding coverage" | Layer 6 doc-wide — section→invariant and audit-finding-ID→invariant coverage matrices with a capped, prioritised gap list. Mirror of `/spec-adversary` (probes spec→doc gap instead of code→doc gap). | hellebuyck |
 
 ## Onboarding & status (governance)
 

--- a/crosscheck/skills/audit-invariant-consistency/SKILL.md
+++ b/crosscheck/skills/audit-invariant-consistency/SKILL.md
@@ -1,0 +1,459 @@
+---
+name: audit-invariant-consistency
+description: >-
+  Layer 5 + 6 hybrid consistency audit. Given a glob of invariant docs and
+  an optional spec, runs three passes (within-module contradictions,
+  cross-module contradictions, invariant-vs-spec contradictions) and emits
+  a capped, prioritised findings file with 4-path triage blocks
+  (`Accept (amend spec)` is first-class). Doc-wide pre-test probe — distinct
+  from /intent-check's single-invariant-with-test post-test probe.
+  Independently useful as a standalone audit; also consumed by
+  add-orchestrator as the consistency leg of the spec-driven fast path.
+  Triggers: "are these invariants consistent", "find contradictions",
+  "consistency audit", "invariant contradictions".
+argument-hint: "<invariant-docs-glob> [spec-path]"
+---
+
+# /audit-invariant-consistency — Cross-Doc Consistency Audit (Layer 5 + 6)
+
+## Description
+
+Three failure modes hide in any set of invariant docs:
+
+1. **Within-module contradictions.** Two invariants in the same module
+   doc constrain the same object incompatibly. The doc compiles to prose
+   that reads cleanly; the constraints fight on the page.
+2. **Cross-module contradictions.** Two invariants in different module
+   docs use the same domain noun with incompatible meanings, or describe
+   the same constraint with disagreeing strength. Each module reads fine
+   in isolation; the system as a whole is incoherent. **This is the
+   load-bearing case.**
+3. **Invariant-vs-spec contradictions.** An invariant's English statement
+   contradicts the prose of its anchoring spec section. The PR #94 `_FILE`-wins
+   resolution between the ngst issue spec and `CONVENTIONS.md` is the
+   canonical worked example: the invariant draft surfaced a contradiction
+   that neither doc had noticed.
+
+All three are silent until someone audits cross-doc. This skill runs that
+audit.
+
+### Layer classification
+
+This is a Layer 5 + Layer 6 hybrid skill:
+
+- The invariant-vs-spec pass is **Layer 5** (spec–intent alignment) —
+  doc-wide pre-test, distinct from `/intent-check`'s single-invariant +
+  covering-test + diff post-test probe.
+- The within-module and cross-module passes are **Layer 6** (spec
+  completeness — invariant set internal consistency).
+
+Layer 5 vs Layer 6 distinction matters for kill criteria and best-effort
+honesty: see Step 9 below.
+
+### Distinct from /intent-check
+
+| Skill | Inputs | Trigger time | Pass shape |
+|---|---|---|---|
+| `/intent-check` | One invariant + one covering test + one code diff | Post-test, per-PR | Two-LLM round-trip informalisation (probabilistic, FP-tracked, 30% kill criterion) |
+| `/audit-invariant-consistency` | Glob of invariant docs + optional spec | Pre-test, doc-wide | Three-pass static cross-reference (best-effort, severity-ranked) |
+
+Use `/intent-check` to verify *one* invariant captures intent of *one*
+test/diff. Use this skill to verify the *set* of invariants is
+self-consistent and consistent with the spec.
+
+## When to invoke
+
+Trigger phrases: `"are these invariants consistent"`, `"find contradictions"`,
+`"consistency audit"`, `"invariant contradictions"`, `"audit invariants
+for inconsistencies"`, `"do my invariants contradict each other"`.
+
+Typical invocations:
+
+- `/crosscheck:audit-invariant-consistency docs/invariants/*.md` —
+  within-module + cross-module passes only; no spec supplied.
+- `/crosscheck:audit-invariant-consistency docs/invariants/*.md docs/design/<repo>-spec.md`
+  — all three passes including invariant-vs-spec.
+- Called by `add-orchestrator` step 7 as the consistency leg of the
+  spec-driven fast path.
+
+## Methodology (execute in order)
+
+### Step 1: Resolve inputs
+
+- **Invariant-docs glob** (required, positional 1). Refuse if zero
+  matches.
+- **Spec path** (optional, positional 2). If supplied, validate the file
+  exists. If not supplied, skip the invariant-vs-spec pass and note in the
+  output that the third pass was skipped.
+
+If the orchestrator marker file `.assurance/add-session-*/session.json`
+exists AND its `spec_path` matches the supplied spec, write to
+`.assurance/add-session-<id>/findings-consistency.md`; otherwise write
+to `<cwd>/findings-consistency.md`. Detect via filesystem.
+
+### Step 2: Build the vocabulary map
+
+For every invariant doc:
+
+- Enumerate every `IN.` heading (`I1`, `I2`, `I1a`, etc.).
+- For each invariant, extract:
+  - Statement (the one-paragraph body)
+  - `Why:` text (often cites a spec section or audit-finding ID)
+  - Domain nouns used (proper nouns, bolded terms, terms defined in the
+    doc's `Contract` or glossary section)
+  - Quantifiers and modal verbs (`for all`, `there exists`, `must`,
+    `should`, `never`, `always`)
+
+Build:
+
+- **Per-module noun set** — `{module → {noun: [IN_ids that use it]}}`
+- **Cross-module shared-noun set** — `{noun: [(module, IN_id) pairs]}`
+  for every noun that appears in ≥ 2 modules
+- **Statement index** — `{(module, IN_id): statement_text}` for evidence
+  citation
+
+This map drives Steps 3–5; do not skip it.
+
+### Step 3: Within-module pass
+
+For each invariant doc, find pairs of invariants `(IN_a, IN_b)` in the
+same doc where:
+
+- They reference the same domain object (same noun in the statement).
+- Their constraints are incompatible:
+  - Different quantifiers on the same property (`for all X` vs
+    `there exists X`).
+  - Disagreeing modal strength on overlapping conditions (`must always`
+    vs `must never`).
+  - Overlapping but contradictory state transitions (`terminal states
+    are immutable` vs `failed states can transition to pending`).
+
+For each contradictory pair, classify the sub-category:
+
+- `incompatible_quantifiers`
+- `disagreeing_modals`
+- `state_transition_conflict`
+- `overlapping_scope_disagreement`
+
+Confidence levels:
+
+- **HIGH** — both statements literally contain the contradicting
+  language; no interpretation needed.
+- **MEDIUM** — the contradiction depends on a domain-noun definition that
+  both invariants share but neither states.
+- **LOW** — plausible contradiction under one reading; not under
+  another.
+
+Skip LOW contradictions in the output unless fewer than 5 HIGH/MEDIUM
+findings exist across all passes.
+
+### Step 4: Cross-module pass (LOAD-BEARING)
+
+For every shared noun in the cross-module noun set:
+
+- Collect every `(module, IN_id)` that uses the noun.
+- Read each invariant's statement; classify how the noun is used:
+  - **Definition** — the invariant defines a property of the noun.
+  - **Constraint** — the invariant constrains how the noun behaves.
+  - **Reference** — the invariant mentions the noun but doesn't constrain
+    it.
+
+Compare definitions across modules:
+
+- If two modules define the same noun differently (different states,
+  different boundaries, different lifecycle), flag as a
+  `cross-module-definition-disagreement`.
+- If one module constrains the noun in a way that another module's
+  constraint forbids, flag as a `cross-module-constraint-conflict`.
+
+This pass is the load-bearing case for the skill. Most cross-doc bugs
+land here: each module's author was correct in isolation; the system
+becomes incoherent in composition.
+
+Example (illustrative, not literal):
+
+```
+Cross-module-definition-disagreement: `expired`
+
+- dispatcher.md I3: "A run is `expired` if its deadline has passed."
+- canceller.md I7: "A run is `expired` if its failure-budget has been
+  tripped."
+
+The same noun names two different conditions. Code reading
+`dispatcher.IsExpired(r)` and `canceller.IsExpired(r)` will get
+different answers; tests written against one definition will not catch
+violations of the other.
+```
+
+Same confidence levels (HIGH/MEDIUM/LOW) as Step 3. Same skip-LOW rule.
+
+### Step 5: Invariant-vs-spec pass (skip if no spec)
+
+For each invariant:
+
+- Locate its anchoring spec section. Signals (in priority order):
+  - `Why:` text contains a section number (`§3.2`, `Section 3.2`,
+    `spec §3.2`).
+  - `Why:` text contains an audit-finding ID that maps to a section
+    (require the spec's audit-finding table to make this mapping).
+  - Domain-noun overlap with a single section (high-confidence match
+    only — ≥ 3 shared domain nouns).
+- If no anchoring section can be identified, skip the invariant for this
+  pass and record `(module, IN_id)` in the "unmapped invariants" list at
+  the bottom of the output.
+
+For mapped invariants:
+
+- Read the anchoring section in full.
+- Check whether the invariant's statement is consistent with the
+  section's prose:
+  - **Contradiction.** Invariant asserts `MUST X`; section asserts `MUST
+    NOT X`. Flag as `invariant-contradicts-spec`.
+  - **Over-strengthening.** Invariant asserts `MUST X`; section asserts
+    `SHOULD X`. Flag as `invariant-stronger-than-spec` (often
+    intentional, but worth surfacing for review).
+  - **Under-strengthening.** Invariant asserts `SHOULD X`; section
+    asserts `MUST X`. Flag as `invariant-weaker-than-spec` (usually a
+    bug).
+  - **Scope mismatch.** Invariant constrains a sub-case the section
+    does not address, or skips a sub-case the section requires. Flag
+    as `invariant-scope-mismatch`.
+
+Cite paired evidence in every finding:
+
+- Invariant: `<module>/<doc>:<IN_id>` plus quote.
+- Spec: `<spec-path>:<line-range>` plus quote.
+
+### Step 6: Aggregate and cap
+
+Combine findings from all three passes. **Cap total output at 15
+findings** — same reviewer-fatigue rationale as `/audit-spec-coverage`
+and `/spec-adversary`.
+
+Prioritisation rules (descending priority):
+
+1. Invariant-vs-spec contradictions (Layer 5, highest signal).
+2. Cross-module-constraint-conflict (the load-bearing Layer 6 case).
+3. Cross-module-definition-disagreement.
+4. Within-module state-transition conflicts.
+5. Within-module incompatible quantifiers.
+6. All other categories at HIGH confidence.
+7. Invariant-stronger-than-spec / invariant-weaker-than-spec.
+8. MEDIUM confidence findings.
+9. Scope mismatches.
+10. LOW confidence findings (only if total < 5).
+
+If more than 15 candidates pass the priority filter, drop the lowest and
+record: `... and N more lower-priority findings omitted; re-run with a
+narrower glob to see them`.
+
+### Step 7: Emit findings-consistency.md
+
+Schema:
+
+```markdown
+---
+session: <id or "standalone">
+category: consistency
+generated_at: <YYYY-MM-DDTHH:MM:SSZ>
+invariant_glob: <glob>
+spec_path: <path or "(none supplied)">
+total_findings: <n>
+passes_run: within-module, cross-module, invariant-vs-spec
+---
+
+# Findings: invariant consistency
+
+## Summary
+
+- Invariant docs audited: <N>
+- Invariants enumerated: <N>
+- Shared domain nouns (≥ 2 modules): <N>
+- Within-module findings: <N>
+- Cross-module findings: <N>
+- Invariant-vs-spec findings: <N or "pass skipped (no spec)">
+- Total findings (capped at 15): <N>
+- Findings omitted as lower-priority: <N or "0">
+
+## Within-module contradictions
+
+### F1: <short name, e.g. "queue.md I3 vs I7 — terminal-state immutability">
+**Severity:** Blocker | High | Medium | Low
+**Sub-category:** incompatible_quantifiers | disagreeing_modals | state_transition_conflict | overlapping_scope_disagreement
+**Confidence:** HIGH | MEDIUM | LOW
+**Evidence:**
+- `<module>/<doc>:<IN_a>` — "<verbatim statement quote>"
+- `<module>/<doc>:<IN_b>` — "<verbatim statement quote>"
+**Why this matters:** <2-3 sentences naming the bug class this admits>
+**Proposed resolution:** <one sentence; typically "reword <IN_a> to clarify <X>" or "split <IN_b> into sub-invariants">
+
+**Triage (mark exactly one):**
+- [ ] Accept (fix invariant) — <one-line fix description>
+- [ ] Accept (amend spec via /protected-surface-amend) — <one-line note on spec edit>
+- [ ] Reject — <reason>
+- [ ] Defer — <revisit condition>
+
+### F2: ...
+
+## Cross-module contradictions
+
+### F<n>: <short name>
+**Severity:** ...
+**Sub-category:** cross-module-definition-disagreement | cross-module-constraint-conflict
+**Confidence:** ...
+**Evidence:**
+- `<module_a>/<doc>:<IN_id>` — "<quote>"
+- `<module_b>/<doc>:<IN_id>` — "<quote>"
+- Shared noun: `<noun>` used in <module_a> as `<sense_a>`, in <module_b> as `<sense_b>`
+**Why this matters:** ...
+**Proposed resolution:** ...
+
+**Triage (mark exactly one):**
+- [ ] Accept (fix invariant) — <one-line fix description>
+- [ ] Accept (amend spec via /protected-surface-amend) — <one-line note on spec edit>
+- [ ] Reject — <reason>
+- [ ] Defer — <revisit condition>
+
+## Invariant-vs-spec contradictions
+
+(If no spec supplied: "Pass skipped — no spec path provided.")
+
+### F<n>: <short name>
+**Severity:** ...
+**Sub-category:** invariant-contradicts-spec | invariant-stronger-than-spec | invariant-weaker-than-spec | invariant-scope-mismatch
+**Confidence:** ...
+**Evidence:**
+- Invariant: `<module>/<doc>:<IN_id>` — "<quote>"
+- Spec: `<spec-path>:<line-range>` — "<quote>"
+**Why this matters:** ...
+**Proposed resolution:** <one sentence; for `invariant-contradicts-spec`, options are "fix invariant" or "amend spec — sometimes the spec is the one that's wrong; see PR #94 _FILE-wins resolution">
+
+**Triage (mark exactly one):**
+- [ ] Accept (fix invariant) — <one-line fix description>
+- [ ] Accept (amend spec via /protected-surface-amend) — <one-line note on spec edit>
+- [ ] Reject — <reason>
+- [ ] Defer — <revisit condition>
+
+## Unmapped invariants
+
+(Invariants whose anchoring spec section could not be identified; review
+manually if the invariant-vs-spec pass was expected to cover them.)
+
+- `<module>/<doc>:<IN_id>` — no spec section identified (cite reason: no
+  section citation in Why, no audit-finding ID, insufficient noun overlap)
+```
+
+Severity rubric:
+
+- **Blocker** — `invariant-contradicts-spec` at HIGH confidence on a
+  spec `MUST` constraint, OR `cross-module-constraint-conflict` at HIGH
+  confidence where both modules ship to the same binary.
+- **High** — `cross-module-definition-disagreement` at HIGH confidence,
+  OR within-module `state_transition_conflict` at HIGH confidence.
+- **Medium** — MEDIUM confidence findings of any sub-category, OR
+  `invariant-stronger-than-spec`.
+- **Low** — `invariant-scope-mismatch`, `invariant-weaker-than-spec` on
+  `SHOULD` constraints, LOW confidence findings.
+
+Sort within each pass by severity (Blocker first); secondary sort
+alphabetical by module name.
+
+### Step 8: Required "What this does NOT catch" section
+
+Append verbatim:
+
+```markdown
+## What this does NOT catch
+
+This skill probes structural consistency. It cannot detect:
+
+1. **Semantic-equivalence contradictions where the prose uses different
+   words for the same constraint.** If two invariants assert the same
+   property in different vocabulary, the skill sees them as unrelated
+   and does not flag redundancy. This is a coverage probe failure, not
+   a consistency probe failure, but it is worth knowing.
+2. **Contradictions internal to the spec itself.** If the spec is
+   self-contradictory (e.g. §3.2 says `X MUST` and §7.4 says `X MUST
+   NOT`), this skill will compare invariants to each section
+   independently and see consistency. Detecting spec-internal
+   contradictions is out of scope — the spec is treated as authoritative
+   for each section. Run a separate spec-internal-consistency review if
+   the spec is large or has been edited by multiple authors.
+3. **Contradictions that depend on running the code.** If two invariants
+   are statically consistent but produce conflicting runtime behaviour
+   under specific inputs, this skill will not catch them. Use
+   `/intent-check` post-test or `/spec-adversary` for code-vs-doc
+   probes.
+4. **Cross-pair compositional contradictions.** A chain `I1 → I2 → I3`
+   may be inconsistent at the chain level even if each pairwise check
+   passes. Chains of length > 2 are not analysed.
+5. **Domain-noun aliasing.** If two modules use different nouns for
+   the same concept (`run` vs `job`), the cross-module pass will not
+   detect that they refer to the same thing. Aliasing detection is
+   beyond static text analysis.
+
+The skill is best-effort by design. Layer 6 has no theorem for
+"completeness of consistency checking"; the goal is high-signal
+findings, not exhaustive coverage.
+```
+
+### Step 9: Kill criteria
+
+This skill is Layer 5/6 best-effort:
+
+- **Signal-to-noise < 1:5 after 4 runs** → the cross-module domain-noun
+  threshold may be too loose; recalibrate.
+- **Zero findings on an invariant set with ≥ 20 invariants across ≥ 3
+  modules sharing visible domain nouns** → suspect a bug; the
+  vocabulary map is probably not detecting shared nouns.
+
+If a tracker file `.assurance/audit-invariant-consistency-tracker.md`
+exists, append a one-line summary (date, counts, accepted count once
+filled in by review). If not, do not create — tracker creation is the
+user's choice.
+
+## Output structure
+
+Single `findings-consistency.md` file at:
+
+- Orchestrator mode: `.assurance/add-session-<id>/findings-consistency.md`
+- Standalone mode: `<cwd>/findings-consistency.md`
+
+The skill writes the file and prints its path. It does NOT modify any
+invariant doc or the spec. Triage and apply are downstream (manual or via
+`add-orchestrator` step 10, including `/protected-surface-amend` invocation
+when `Accept (amend spec)` triages).
+
+## Checklist before handing off
+
+- [ ] Invariant glob resolved to at least one file
+- [ ] Spec path validated if supplied; pass skipped explicitly if not
+- [ ] Vocabulary map built; per-module and cross-module noun sets
+      populated
+- [ ] Within-module pass executed for every doc
+- [ ] Cross-module pass executed for every shared-noun pair
+- [ ] Invariant-vs-spec pass executed (or stated skipped)
+- [ ] Each finding has paired file:line evidence
+- [ ] 4-path triage block per finding (with `Accept (amend spec)` as a
+      first-class option, especially for invariant-vs-spec contradictions)
+- [ ] ≤ 15 findings emitted (with overflow note if applicable)
+- [ ] Unmapped invariants list present (or stated empty)
+- [ ] "What this does NOT catch" section present
+- [ ] Output written to correct path
+
+## Arguments
+
+1. **Invariant docs glob** (required) — glob pattern matching the
+   invariant docs to audit.
+2. **Spec path** (optional) — repo-relative or absolute path. Enables the
+   invariant-vs-spec pass when supplied.
+
+Examples:
+
+- `/audit-invariant-consistency docs/invariants/*.md` — within-module +
+  cross-module passes only.
+- `/audit-invariant-consistency docs/invariants/*.md docs/design/fabricator-spec.md`
+  — all three passes against the ngst spec.
+- `/audit-invariant-consistency docs/invariants/queue*.md` — narrow glob
+  for the queue module family.
+- `/audit-invariant-consistency` — prompt for the glob; do not guess.

--- a/crosscheck/skills/audit-spec-coverage/SKILL.md
+++ b/crosscheck/skills/audit-spec-coverage/SKILL.md
@@ -1,0 +1,345 @@
+---
+name: audit-spec-coverage
+description: >-
+  Layer 6 spec-coverage probe. Given a prose spec and a glob of invariant
+  docs, emits two coverage matrices (spec section → invariant IDs;
+  audit-finding ID → invariant IDs) plus a prioritised gap list and 4-path
+  triage blocks. Mirrors /spec-adversary's discipline (capped output, kill
+  criteria, "what this does NOT catch" honesty). Independently useful as a
+  standalone audit; also consumed by add-orchestrator as the coverage leg of
+  the spec-driven fast path. Triggers: "spec coverage", "coverage matrix",
+  "which spec sections lack invariants", "audit-finding coverage".
+argument-hint: "<spec-path> [invariant-docs-glob]"
+---
+
+# /audit-spec-coverage — Spec-Coverage Audit (Layer 6)
+
+## Description
+
+Layer 6 of the assurance hierarchy — *spec completeness* — has two failure
+modes that this skill probes:
+
+1. **Sections of the prose spec with no invariant doc covering them.** The
+   spec asserts a constraint; no invariant captures it; the constraint
+   silently disappears from the enforceable surface.
+2. **Audit-finding IDs (the §14.3-style traceability tables in mature
+   specs) with no invariant covering them.** The spec audit caught a class
+   of failure; no invariant prevents its recurrence.
+
+Both are coverage gaps, both are silent unless someone runs this audit.
+
+The skill is the mirror image of `/spec-adversary`:
+
+| Skill              | Question it answers                                           |
+|--------------------|---------------------------------------------------------------|
+| `/spec-adversary`  | "Given an invariant doc, what is it missing about the code?"  |
+| `/audit-spec-coverage` | "Given a prose spec, what is the invariant doc set missing about the spec?" |
+
+`/spec-adversary` probes the code-vs-doc gap. This skill probes the
+spec-vs-doc gap. Use both for full Layer 6 coverage.
+
+This is **best-effort, like all Layer 6 work.** Coverage by section and
+audit-finding ID is a structural check; it does not catch cross-module
+semantic gaps where the same constraint hides under different domain nouns,
+and it does not catch constraints the spec itself omits but the code
+enforces. See "What this does NOT catch" below.
+
+## When to invoke
+
+Trigger phrases: `"spec coverage"`, `"coverage matrix"`, `"which spec
+sections lack invariants"`, `"audit-finding coverage"`, `"spec section
+coverage"`, `"audit which spec sections are uncovered"`.
+
+Typical invocations:
+
+- `/crosscheck:audit-spec-coverage docs/design/<repo>-spec.md` — default
+  invariant glob `docs/invariants/*.md`.
+- `/crosscheck:audit-spec-coverage docs/design/<repo>-spec.md docs/invariants/*.md`
+  — explicit glob.
+- Called by `add-orchestrator` step 7 as the coverage leg of the spec-driven
+  fast path.
+
+## Methodology (execute in order)
+
+### Step 1: Resolve inputs
+
+- **Spec path** (required, positional 1). Refuse with a clear error if the
+  file does not exist or is empty.
+- **Invariant-docs glob** (optional, positional 2; default
+  `docs/invariants/*.md`). If the glob matches zero files, refuse with
+  "no invariant docs found — run `/crosscheck:draft-invariants` first".
+
+If the orchestrator marker file `.assurance/add-session-*/session.json`
+exists in cwd or ancestors AND its `spec_path` matches the supplied spec,
+write output to `.assurance/add-session-<id>/findings-coverage.md` instead
+of the default cwd `findings-coverage.md`. Detect via filesystem; do not
+require a flag.
+
+### Step 2: Enumerate the spec
+
+Read the spec end to end. Build a section index:
+
+- For each `## <N>` / `### <N.M>` / `#### <N.M.K>` heading, record:
+  - Section number (e.g. `§3.2`, `§6.4.1`)
+  - Section title
+  - RFC-2119 keyword density (count of `MUST`, `MUST NOT`, `SHALL`,
+    `SHALL NOT`, `SHOULD`, `SHOULD NOT`, `MAY`)
+  - Domain nouns (proper nouns + bolded terms + glossary entries within
+    the section body)
+  - Byte range (start/end line numbers) — needed for evidence citations
+
+Detect any audit-finding traceability table (commonly §14, §15, or an
+appendix; identifiable by columns like `ID | Severity | Section | Status`
+or RFC-2119-keyworded rows mapping finding IDs to sections):
+
+- Enumerate every audit-finding ID (`C1`, `C2`, `I1`, `I7`, `M3`, `V12`,
+  etc. — the exact ID scheme varies by spec).
+- For each ID, record the linked spec section and a one-line description
+  from the table.
+- If no audit-finding table is found, record this as a deliberate
+  observation in the output ("no audit-finding table found in this spec";
+  the audit-finding-coverage matrix is then empty).
+
+### Step 3: Enumerate the invariants
+
+For each invariant doc:
+
+- Identify every `IN.` heading (`I1.`, `I2.`, ..., `I7.`, plus sub-IDs
+  like `I1a.` if present).
+- For each invariant:
+  - Statement (the one-paragraph English body)
+  - `Why:` rationale (which often cites a spec section or audit-finding
+    ID)
+  - `Test:` sketch
+  - Domain nouns it uses
+
+Build a flat list of `(module, IN_id, statement_snippet, why_text)` rows
+across all docs.
+
+### Step 4: Section-coverage matrix
+
+For each spec section, list the invariant IDs that cover it. Coverage
+signals:
+
+- **Direct citation.** Invariant `Why:` text contains the section number
+  (`§3.2`, `Section 3.2`, etc.) or an unambiguous title reference.
+- **Domain-noun overlap.** Invariant uses domain nouns the section
+  introduces (above a noun-overlap threshold; default ≥ 2 shared
+  domain-specific nouns, excluding generic terms).
+- **Audit-finding back-link.** Invariant cites an audit-finding ID from the
+  §14.3 table, and that ID maps to the section.
+
+A section is **UNCOVERED** if no invariant satisfies any of these signals.
+A section is **PARTIALLY COVERED** if at least one signal fires but the
+section has multiple distinct constraints (RFC-2119 keyword count > 3) and
+not all of them are addressed.
+
+Emit the matrix as a markdown table:
+
+```
+| Spec section | RFC-2119 weight | Covering invariants | Coverage status |
+|---|---|---|---|
+| §3.2 Webhook handler | 4× MUST | secrets.I1, secrets.I3 | COVERED |
+| §6.4 Cancellation propagation | 2× MUST, 1× SHOULD | (none) | UNCOVERED |
+| §9.1 Failure-budget tripping | 3× MUST | budget.I1 | PARTIAL — 3 MUSTs, 1 covered |
+| ... | ... | ... | ... |
+```
+
+### Step 5: Audit-finding-ID coverage matrix
+
+If §3 found an audit-finding table:
+
+For each audit-finding ID, list the invariant IDs whose `Why:` mentions
+that ID (case-sensitive exact match) or whose statement clearly addresses
+the failure class the audit caught.
+
+Emit the matrix:
+
+```
+| Audit-finding ID | Description | Linked spec section | Covering invariants | Coverage status |
+|---|---|---|---|---|
+| I7 | _FILE-wins disambiguation | §12.2 | secrets.I7 | COVERED |
+| C3 | Webhook signature replay | §3.4 | (none) | UNCOVERED |
+| ... | ... | ... | ... | ... |
+```
+
+If no audit-finding table was found, state this explicitly:
+
+> No audit-finding traceability table detected in `<spec-path>`. Audit-finding-ID coverage matrix is empty — this is normal for specs without an embedded audit catalogue.
+
+### Step 6: Prioritised gap list
+
+Collect all `UNCOVERED` items (from both matrices). Order by load-bearing
+weight:
+
+1. Sections with `MUST` / `MUST NOT` / `SHALL` keywords (descending count).
+2. Sections with `SHOULD` / `SHOULD NOT` keywords.
+3. Audit-finding IDs (ordered by their `Severity` column if the table has
+   one; otherwise by source order).
+4. Sections with `MAY` keywords (informational).
+
+**Cap output at 15 gaps.** If more candidates exist, drop the lowest-weight
+items and record `... and N more lower-weight items omitted; re-run with a
+narrower invariant glob to see them` in the output.
+
+This cap mirrors `/spec-adversary`'s ≤3 cap rationale: reviewer fatigue is
+the dominant failure mode. 15 is the scaled-up coverage analog — high
+enough to capture the load-bearing surface, low enough to triage in one
+sitting.
+
+### Step 7: Emit findings-coverage.md
+
+Write the output file. Schema:
+
+```markdown
+---
+session: <id or "standalone">
+category: coverage
+generated_at: <YYYY-MM-DDTHH:MM:SSZ>
+spec_path: <path>
+invariant_glob: <glob>
+total_findings: <n>
+---
+
+# Findings: spec coverage
+
+## Summary
+
+- Spec sections enumerated: <N>
+- Audit-finding IDs enumerated: <N or "no table found">
+- Invariants enumerated: <N across M modules>
+- Uncovered sections: <N>
+- Uncovered audit-finding IDs: <N>
+- Findings emitted (capped at 15): <N>
+- Findings omitted as lower-weight: <N or "0">
+
+## Section coverage matrix
+
+<table from Step 4>
+
+## Audit-finding-ID coverage matrix
+
+<table from Step 5, or "No audit-finding table detected">
+
+## Prioritised gaps
+
+### F1: <short name, e.g. "§6.4 Cancellation propagation uncovered">
+**Severity:** Blocker | High | Medium | Low
+**Category:** spec-section-uncovered | audit-finding-uncovered | section-partially-covered
+**Evidence:**
+- Spec: `<spec-path>:<line-range>` — <quote of the relevant RFC-2119 constraint>
+- Invariants: (none match) | <module>/<doc>:<IN_id> matches partially because <reason>
+**Why this matters:** <2-3 sentences naming the failure class this gap admits>
+**Proposed resolution:** <one sentence; usually "add an invariant covering <X> to <module>.md">
+
+**Triage (mark exactly one):**
+- [ ] Accept (fix invariant) — <one-line fix description>
+- [ ] Accept (amend spec via /protected-surface-amend) — <one-line note on spec edit>
+- [ ] Reject — <reason>
+- [ ] Defer — <revisit condition>
+
+### F2: ...
+...
+```
+
+Severity rubric:
+- **Blocker** — RFC-2119 `MUST` / `MUST NOT` constraint uncovered, OR audit-finding ID labelled `critical` / `high` uncovered.
+- **High** — RFC-2119 `SHALL` constraint uncovered, OR audit-finding ID labelled `medium`.
+- **Medium** — RFC-2119 `SHOULD` constraint uncovered, OR audit-finding ID labelled `low`.
+- **Low** — RFC-2119 `MAY` constraint uncovered, OR a section with no RFC-2119 keywords but explicit invariant-shaped prose ("the system always ...", "for all X ...").
+
+Sort gaps by severity (Blocker first); within severity, sort by spec section number.
+
+### Step 8: Required "What this does NOT catch" section
+
+Mirror `/spec-adversary`'s honesty discipline. Append this section to the
+output verbatim, then add any spec-specific caveats discovered during the
+run:
+
+```markdown
+## What this does NOT catch
+
+This skill is a structural coverage probe. It detects gaps in the
+section → invariant and audit-finding → invariant mappings. It cannot
+detect:
+
+1. **Cross-module semantic gaps where domain nouns differ.** If `module_a`
+   names a concept `expired` and `module_b` names the same concept
+   `past-deadline`, this skill will see both as covered when in fact one
+   module has imported a different definition. Use
+   `/audit-invariant-consistency` for the cross-module pass.
+2. **Constraints the spec itself omits but the code enforces.** If the
+   spec is silent on a property but the code defends it, this skill
+   reports the spec as authoritative. Use `/spec-adversary` for the
+   code-vs-doc gap probe.
+3. **Gaps inside the audit-finding table itself.** If the table is
+   incomplete (the audit was partial), the matrix will reflect the
+   incomplete table. The skill does not re-audit the spec from scratch.
+4. **Subtle constraint composition.** Two `SHOULD` constraints that
+   together imply a `MUST` are reported as two `SHOULD`s. Compositional
+   reasoning is not in scope.
+5. **Stale invariant doc citations.** If an invariant cites `§3.2` but
+   §3.2 has been renumbered to §3.3, the citation may match the old
+   number and miss the new section. Re-run after spec renumbering.
+
+When in doubt, treat a `COVERED` row with low evidence (single domain-noun
+overlap, no direct citation) as `PARTIAL` and probe further.
+```
+
+### Step 9: Kill criteria
+
+This skill is Layer 6 best-effort. Track its signal-to-noise:
+
+- **Signal-to-noise < 1:5 after 4 runs** (fewer than 1 accepted gap per
+  5 emitted) → the audit is mostly false positives; recalibrate domain-noun
+  threshold or re-run with a different invariant glob.
+- **Zero findings on a spec with ≥ 20 RFC-2119 keywords across multiple
+  modules with no invariant docs** → suspect a bug; the skill is missing
+  the section-extraction logic, not finding genuine coverage.
+
+If a tracker file `.assurance/audit-spec-coverage-tracker.md` exists,
+append a one-line summary of this run (counts, date). If not, do not
+create one — tracker creation is the user's choice.
+
+## Output structure
+
+A single `findings-coverage.md` file at one of:
+
+- Orchestrator mode: `.assurance/add-session-<id>/findings-coverage.md`
+- Standalone mode: `<cwd>/findings-coverage.md`
+
+The skill writes the file and prints its path. It does NOT modify the spec
+or any invariant doc. Triage and apply are downstream tasks (manual, or
+via `add-orchestrator` step 10).
+
+## Checklist before handing off
+
+- [ ] Spec path validated; file exists and is non-empty
+- [ ] Invariant glob resolved to at least one file
+- [ ] Every spec section enumerated by number
+- [ ] RFC-2119 keyword density recorded per section
+- [ ] Audit-finding table detected (or absence stated explicitly)
+- [ ] Every invariant doc's `IN.` IDs enumerated
+- [ ] Section-coverage matrix complete
+- [ ] Audit-finding-coverage matrix complete (or stated empty)
+- [ ] Gaps prioritised by RFC-2119 weight
+- [ ] ≤ 15 gaps emitted (with overflow note if applicable)
+- [ ] Each gap has 4-path triage block with `Accept (amend spec)` as a
+      first-class option
+- [ ] "What this does NOT catch" section present
+- [ ] Output written to correct path (orchestrator vs standalone)
+
+## Arguments
+
+1. **Spec path** (required) — absolute or repo-relative path to the prose
+   spec to audit.
+2. **Invariant docs glob** (optional, default `docs/invariants/*.md`) —
+   glob pattern for the invariant docs to audit against.
+
+Examples:
+
+- `/audit-spec-coverage docs/design/fabricator-spec.md` — audit the ngst
+  spec against all invariant docs in `docs/invariants/`.
+- `/audit-spec-coverage docs/specs/queue.md docs/invariants/queue*.md` —
+  narrower glob for a single module's invariant set.
+- `/audit-spec-coverage` — prompt for the spec path; do not guess.


### PR DESCRIPTION
## Summary

Two new Layer 5/6 audit skills that probe invariant doc sets for coverage and consistency gaps. Each is independently useful as a standalone audit and will be consumed by the upcoming `add-orchestrator` agent (PR 3) as the coverage/consistency legs of the spec-driven fast path.

- `/audit-spec-coverage` (Layer 6) — section→invariant and audit-finding-ID→invariant coverage matrices with capped (≤15) prioritised gap list. Mirror of `/spec-adversary` — probes spec→doc gap instead of code→doc gap.
- `/audit-invariant-consistency` (Layer 5+6) — three passes (within-module, cross-module, invariant-vs-spec) emitting capped (≤15) consistency findings with paired evidence. Doc-wide pre-test probe, distinct from `/intent-check`'s single-invariant post-test probe.

Both skills:
- Cap output at 15 findings (reviewer-fatigue calibration; mirrors `/spec-adversary`'s ≤3 rationale at coverage scale).
- Make `Accept (amend spec via /protected-surface-amend)` a first-class triage option — sometimes the spec is the one that's wrong (ngst PR #94 `_FILE`-wins resolution is the worked example).
- Include explicit "What this does NOT catch" honesty sections documenting known blind spots.
- Document signal-to-noise kill criteria.

## Context

First of three PRs codifying the v2 ADD retrospective's spec-driven fast path (see plan at `~/.claude/plans/i-ve-been-trialing-add-quizzical-bunny.md`). PR 2 will add a marker-aware mode to `/draft-invariants`; PR 3 will add the `add-orchestrator` agent that composes all of it.

Independent of PRs 2/3 — these skills ship standalone value.

## Files changed

- `crosscheck/skills/audit-spec-coverage/SKILL.md` (new)
- `crosscheck/skills/audit-invariant-consistency/SKILL.md` (new)
- `crosscheck/agents/hellebuyck.md` — adds 2 routing rows + skill descriptions + Phase 3 SKILL.md read entries + Phase 4 quality-gate updates
- `crosscheck/README.md` — adds the new skills to the persona table
- `crosscheck/docs/skills.md` — adds rows to Layer 5 and Layer 6 sections; updates skill count
- `CLAUDE.md` — adds to spec management & adequacy list

## Test plan

- [ ] Trigger phrases route correctly via hellebuyck (`"spec coverage"`, `"find contradictions"`)
- [ ] Run `/audit-spec-coverage` standalone on `~/repos/ngst/docs/design/ngst-spec.md` against `docs/invariants/*.md` — confirm §14.3 audit-finding ID coverage matrix is produced
- [ ] Run `/audit-invariant-consistency` standalone on the same repo — confirm three-pass output with paired evidence
- [ ] Confirm both skills cap output at 15 findings and include "What this does NOT catch" sections
- [ ] Confirm 4-path triage block format matches the schema in each SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)