### PR TITLE
fix(crosscheck): post-validation skill + agent fixes (D2 + D4)

### DIFF
--- a/crosscheck/agents/add-orchestrator.md
+++ b/crosscheck/agents/add-orchestrator.md
@@ -275,7 +275,7 @@ in the orchestrator's main thread. For each subagent:
   1. `docs/invariants/<module>.md` exists
   2. `Status: Draft` line present
   3. `Audit: pending session <session_id>` line present
-  4. ≥ 3 `IN.` headings present (lower bound for a useful module)
+  4. ≥ 3 invariant headings of the form `## I<N>: <Name>` (h2, grep-anchorable) present. Other styles (h3, bold-prefix paragraph, prose-section with IDs in body) FAIL this gate — see `crosscheck/skills/draft-invariants/SKILL.md` Step 3 *Heading convention* for the canonical form. Grep: `grep -cE '^## I[0-9]+:' docs/invariants/<module>.md` must return ≥ 3.
 
   If any quality-gate criterion fails, treat as a soft failure: record
   the criterion that failed and continue. The downstream audit will

--- a/crosscheck/skills/audit-invariant-consistency/SKILL.md
+++ b/crosscheck/skills/audit-invariant-consistency/SKILL.md
@@ -249,6 +249,8 @@ narrower glob to see them`.
 
 ### Step 7: Emit findings-consistency.md
 
+Write the output file using the Write tool. This is a session-state artifact required for downstream review (the orchestrator's batched triage, or the standalone user's red-pen pass) — it is NOT a documentation file. The "never create documentation files" rule in standard system prompts does NOT apply here. The destination path was either supplied by the caller (orchestrator dispatch) or defaults to `.assurance/add-session-<id>/findings-consistency.md` (orchestrator-mode) or the cwd (standalone mode). Emit the file; do not return the content inline as a substitute.
+
 Schema:
 
 ```markdown

--- a/crosscheck/skills/audit-spec-coverage/SKILL.md
+++ b/crosscheck/skills/audit-spec-coverage/SKILL.md
@@ -189,7 +189,9 @@ sitting.
 
 ### Step 7: Emit findings-coverage.md
 
-Write the output file. Schema:
+Write the output file using the Write tool. This is a session-state artifact required for downstream review (the orchestrator's batched triage, or the standalone user's red-pen pass) — it is NOT a documentation file. The "never create documentation files" rule in standard system prompts does NOT apply here. The destination path was either supplied by the caller (orchestrator dispatch) or defaults to `.assurance/add-session-<id>/findings-coverage.md` (orchestrator-mode) or the cwd (standalone mode). Emit the file; do not return the content inline as a substitute.
+
+Schema:
 
 ```markdown
 ---

--- a/crosscheck/skills/draft-invariants/SKILL.md
+++ b/crosscheck/skills/draft-invariants/SKILL.md
@@ -256,11 +256,17 @@ the user to confirm.
 
 ### 3. Draft candidate invariants (5-8)
 
-Use this format exactly:
+**Heading convention (load-bearing — do NOT vary).** Each invariant MUST be introduced by a level-2 heading of the exact form `## I<N>: <Name>`, where `<N>` is a stable monotonic integer (`I1`, `I2`, …) and `<Name>` is a short PascalCase or kebab-style identifier. The heading is the grep anchor that downstream tooling (`/invariant-coverage-scaffold`, `// Invariant Ix: <Name>` test comments) relies on. Examples that are correct: `## I1: RedactionSentinelString`, `## I7: BothSetFileWins`. Examples that are WRONG and MUST NOT be produced: `### I1 RedactionSentinelString` (h3, not h2), `## Engine selection — single embedding API` (prose-section heading with the ID buried in body), `**I1. RedactionSentinelString.**` (bold-prefix in paragraph; this was the legacy v1 style and is grandfathered for already-shipped docs only). Group invariants under a single `## Invariants` parent only if you need to use `### I<N>: <Name>` (h3) consistently for every invariant — never mix h2 and h3 invariant headings in the same doc.
+
+When dispatched by `add-orchestrator` with the orchestrator marker active, every invariant heading in this doc MUST be h2 (`## I<N>: <Name>`). The heading-convention discipline is enforced at the per-subagent quality gate in `add-orchestrator.md` Step 6.
+
+Use this body format exactly under each heading:
 
 ```
-**IN. Name — short imperative.**
+## I<N>: <Name>
+
 <One or two sentence statement of the property in plain English.>
+
 - *Why:* <real failure class this blocks, tied to specific past incident or audit-finding ID where possible>
 - *Test:* <concrete sketch of how to translate this into a property-based or fuzz test>
 ```


### PR DESCRIPTION
## Summary

Two small upstream fixes surfaced during end-to-end validation of the v2 ADD codification (#179, #180, #181) against ngst's signed-off spec.

**D2 — audit subagents perceived a "no documentation files" harness block on findings output.** Both audit skills' Step 7 sections now explicitly state that the findings file is a session-state artifact (not documentation) and that the standard no-doc rule does NOT apply. During validation, both `/audit-spec-coverage` and `/audit-invariant-consistency` subagents returned the findings content inline and refused to persist, citing the no-doc rule — the orchestrator had to write the files. With this fix the explicit-user-instruction language is no longer needed in dispatch prompts.

**D4 — 14 parallel `/draft-invariants` subagents produced four distinct heading styles.** Pinned `## I<N>: <Name>` (h2, grep-anchorable) as the canonical form in `/draft-invariants` Step 3, with correct/wrong examples and a grandfathering note for the legacy bold-prefix style used in already-shipped docs. The `add-orchestrator` Step 6 per-subagent quality gate now checks the heading form explicitly via `grep -cE '^## I[0-9]+:' ... >= 3`. This matters because `/invariant-coverage-scaffold`'s bidirectional gate relies on grep-anchorable IDs.

Validation report (local, not committed) at `.claude/validation-report-add-orchestrator-2026-05-12.md`.

## Files changed

- `crosscheck/skills/audit-spec-coverage/SKILL.md` — Step 7 write-the-file preamble
- `crosscheck/skills/audit-invariant-consistency/SKILL.md` — Step 7 write-the-file preamble
- `crosscheck/skills/draft-invariants/SKILL.md` — Step 3 heading-convention pin
- `crosscheck/agents/add-orchestrator.md` — Step 6 quality-gate heading check

## What this is NOT

- Not a re-design. The marker logic, parallel-dispatch shape, audit caps, and 4-path triage are unchanged.
- Not the response to D1 (validation plan vs SKILL.md on sub-case d) — SKILL.md is already correct; the plan doc lives outside this repo.
- Not the response to D3 (skill visibility in older sessions) — that's a session-staleness artifact with no code action.

## Test plan

- [ ] On a fresh session, run `/crosscheck:audit-spec-coverage docs/design/<spec>.md` directly (standalone mode) — confirm the findings file lands on disk without "harness blocked" reports
- [ ] On a fresh session, run `/crosscheck:audit-invariant-consistency docs/invariants/*.md docs/design/<spec>.md` — same
- [ ] On a fresh session, dispatch `/crosscheck:draft-invariants <module>` against a marker-aware orchestrator session — confirm output has h2 `## I<N>: <Name>` invariant headings (no h3, no prose-section style, no bold-prefix)
- [ ] On a fresh session, run `/crosscheck:add-orchestrator <spec>` end-to-end on a multi-module spec — confirm Step 6 quality gate rejects any subagent doc whose invariants use a non-h2 form