### PR TITLE
feat(crosscheck): add conformance/inventory oracle + fix assurance-probe frontmatter

### DIFF
--- a/crosscheck/conformance/README.md
+++ b/crosscheck/conformance/README.md
@@ -1,0 +1,74 @@
+# Crosscheck conformance / inventory oracle
+
+The doc-vs-implementation gate for Crosscheck *as a whole*. Same idea as the
+invariant↔test coverage gate, lifted to the meta level: **docs ↔ artifacts.**
+It exists because Crosscheck's own `plausible ≠ correct` failure mode bit its
+maintainer — the docs described a methodology that only partly ships, and
+nothing mechanical said which parts. This is that mechanical check.
+
+It is a self-contained Go module (stdlib only, no third-party deps).
+
+## Run
+
+    go run ./crosscheck/conformance              # from repo root, scans crosscheck/
+    go run ./crosscheck/conformance crosscheck   # explicit root
+    go run ./crosscheck/conformance /path/to/crosscheck
+
+Build a standalone binary:
+
+    go build -o conformance ./crosscheck/conformance
+    ./conformance crosscheck
+
+Exit 0 = PASS, 1 = FAIL (any AUTO error, or any `unreviewed` ledger claim, or a
+`present_artifact` ledger check that disagrees with the filesystem).
+
+> Run commands assume the repo-root Go workspace (`go.work`), which lets the
+> nested module resolve when invoked from the repo root. From inside this
+> directory you can also run `go run . ..` and `go test ./...`.
+
+## Two layers
+
+- **AUTO (deterministic, fails CI):**
+  1. *Structural* — every `skills/<dir>/` has a `SKILL.md` with `name`/`description`
+     frontmatter; `name` matches the dir; agents likewise. Non-empty.
+  2. *Phantom* — docs reference a `/skill` or `/crosscheck:skill` that doesn't exist.
+  3. *Orphan* — an artifact ships but is referenced in no user-facing doc (WARN).
+  4. *MCP* — README-claimed `dafny_*` tools exist in `mcp-server/` source (WARN).
+- **LEDGER (`claims.json`, reviewed not auto-proved):** narrative claims that
+  can't be checked by reference integrity — layer/phase/mode counts, terminal
+  states, self-coverage. Each entry records the claim, the observed reality, a
+  review `status`, and where possible an auto-check that **re-fires if reality
+  changes** (e.g. `agents/lowry.md expect_present:false` flips to FAIL the day
+  Phase 4 ships, forcing the ledger to be updated). `status:"unreviewed"` fails
+  CI to force triage of any new claim.
+
+## First-run findings (2026-05-30, plugin v2.5.1)
+
+- **ERROR** `assurance-probe` — `SKILL.md` had no frontmatter; couldn't load as a
+  skill, yet `byfuglien` routes to it. **Fixed in the PR that introduced this
+  oracle** (frontmatter added; this is why the gate is now GREEN).
+- **WARN** `journal-context` — ships but is undocumented in the user-facing doc
+  set (decide: document or de-scope). Left as-is — a human decision.
+- **LEDGER known-gaps** — Phase 4 agent, operating modes, committed methodology,
+  Phase 5 auditor, self-coverage. See `claims.json`; tracked in the epic.
+
+## Wire to CI (suggested)
+
+```yaml
+# .github/workflows/conformance.yml  (sketch)
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.25' }
+      - run: go run ./crosscheck/conformance crosscheck
+      - run: go test ./crosscheck/conformance/...
+```
+
+## Extend
+
+Add a claim to `claims.json` whenever the docs assert something about the plugin
+that the filesystem doesn't already prove. New claims start `status:"unreviewed"`
+(fails CI) until a human triages them to `reviewed-*` or `known-gap`.

--- a/crosscheck/conformance/claims.json
+++ b/crosscheck/conformance/claims.json
@@ -1,0 +1,69 @@
+{
+  "version": 1,
+  "description": "Narrative claims Crosscheck makes about itself that cannot be verified by reference/structural integrity alone. Each records the claim, the observed reality, a review status, and (where possible) an auto-check that re-fires if reality changes. status='unreviewed' fails CI to force triage.",
+  "narrative_claims": [
+    {
+      "id": "CLAIM-LAYERS",
+      "source": "README.md:3",
+      "claim": "Six layers of correctness checks, four shipping today.",
+      "reality": "Layers 1,4,5,6 have shipping skills; Layers 2 (compilation correctness) and 3 (contract-graph) do not. README discloses this honestly ('four of them are shipping today').",
+      "status": "reviewed-disclosed",
+      "check": {"type": "manual"},
+      "tracked_in": ""
+    },
+    {
+      "id": "CLAIM-ADDORCH-TERMINAL",
+      "source": "agents/add-orchestrator.md",
+      "claim": "add-orchestrator drives spec -> approved invariant docs READY FOR IMPLEMENTATION.",
+      "reality": "Accurate. The agent explicitly stops at the routing recommendation and disclaims implementation-correctness closure. NOT drift.",
+      "status": "reviewed-accurate",
+      "check": {"type": "manual"},
+      "tracked_in": ""
+    },
+    {
+      "id": "CLAIM-PHASE4",
+      "source": "ADD methodology (Phase 4)",
+      "claim": "ADD includes a Phase 4 gated-implementation loop that drives code to green within three legal commit shapes.",
+      "reality": "Designed, not shipped. No implementing agent exists (grep agents/: byfuglien, hellebuyck, add-orchestrator only). This is the run-to-green capability the user expected.",
+      "status": "known-gap",
+      "check": {"type": "present_artifact", "path": "agents/lowry.md", "expect_present": false},
+      "tracked_in": "ISSUE#2 / phase4-agent-handoff.md"
+    },
+    {
+      "id": "CLAIM-MODES",
+      "source": "ADD methodology (ADR-001)",
+      "claim": "Three operating modes (bootstrap / add / transitional) with module-level mode tags honoured by skills.",
+      "reality": "Not wired. add-orchestrator hardwires the signed-off-spec path (Step 1 requires >=10 RFC-2119 keywords) and reads no mode tags. Legacy hardening and empty-repo greenfield have no orchestrated entrypoint.",
+      "status": "known-gap",
+      "check": {"type": "manual"},
+      "tracked_in": "ISSUE#3"
+    },
+    {
+      "id": "CLAIM-METHODOLOGY-COMMITTED",
+      "source": "docs/add/",
+      "claim": "The canonical ADD methodology (methodology.md, glossary.md, the ADRs) lives in the repo.",
+      "reality": "Never committed. Only docs/add/README.md, JOURNAL.md, orchestrator-improvements.md shipped. The phase/mode/diff-classification design exists only in design conversation + the phase4-agent-handoff.md brief.",
+      "status": "known-gap",
+      "check": {"type": "present_artifact", "path": "docs/add/methodology.md", "expect_present": false},
+      "tracked_in": "ISSUE#1 (epic)"
+    },
+    {
+      "id": "CLAIM-AUDITOR",
+      "source": "ADD methodology (ADR-003, Phase 5)",
+      "claim": "A Phase 5 Auditor agent renders settled/active/drifted verdicts on every artifact.",
+      "reality": "Designed, not shipped. No auditor agent exists.",
+      "status": "known-gap",
+      "check": {"type": "present_artifact", "path": "agents/auditor.md", "expect_present": false},
+      "tracked_in": "ISSUE#5"
+    },
+    {
+      "id": "CLAIM-SELF-COVERAGE",
+      "source": "docs/invariants/",
+      "claim": "Crosscheck applies its own assurance machinery to itself.",
+      "reality": "docs/invariants/ covers three helper functions (parseDafnyOutput, shouldExclude, extractDifficultyMetrics) — the plugin verified its leaves, not its trunk (orchestrators, gates, workflow). This conformance oracle is the first trunk-level check.",
+      "status": "known-gap",
+      "check": {"type": "manual"},
+      "tracked_in": "ISSUE#1 (epic)"
+    }
+  ]
+}

--- a/crosscheck/conformance/go.mod
+++ b/crosscheck/conformance/go.mod
@@ -1,0 +1,3 @@
+module github.com/nicholls-inc/claude-code-marketplace/crosscheck/conformance
+
+go 1.25

--- a/crosscheck/conformance/main.go
+++ b/crosscheck/conformance/main.go
@@ -1,0 +1,441 @@
+// Command conformance is the Crosscheck conformance / inventory oracle.
+//
+// It verifies that what the documentation CLAIMS Crosscheck ships matches what
+// the filesystem actually contains. This is the bidirectional-coverage-gate
+// pattern (docs/invariants <-> tests) lifted to the meta level: docs <->
+// artifacts.
+//
+// Two layers of check:
+//
+//	AUTO   - deterministic, no false positives, fail CI on ERROR
+//	         (artifact<->doc reference integrity + structural integrity)
+//	LEDGER - narrative claims from claims.json that can't be auto-verified
+//	         (layer/phase/mode counts, terminal states). Surfaced for review,
+//	         dated, and tracked. Drift here is a known-gap, not a silent one.
+//
+// Exit 1 if any AUTO check is ERROR. LEDGER never fails CI by itself, but any
+// ledger entry with status 'unreviewed' is promoted to an ERROR (forces
+// triage), and a 'present_artifact' auto-check that disagrees with reality is
+// likewise promoted to an ERROR.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// docFiles is the user-facing documentation set scanned for references. Files
+// that do not exist are skipped.
+var docFiles = []string{
+	"README.md",
+	"docs/skills.md",
+	"docs/agents.md",
+	"docs/assurance-hierarchy.md",
+	"docs/research/assurance-hierarchy.md",
+}
+
+// reqKeys are the frontmatter keys every skill and agent must declare.
+var reqKeys = []string{"name", "description"}
+
+var (
+	fmLineRe    = regexp.MustCompile(`^([a-zA-Z0-9_-]+):\s*(.*)$`)
+	slashTokRe  = regexp.MustCompile("\x60/([a-z][a-z0-9-]+)\x60")
+	xcheckRe    = regexp.MustCompile(`/crosscheck:([a-z][a-z0-9-]+)`)
+	dafnyToolRe = regexp.MustCompile("\x60(dafny_[a-z]+)\x60")
+)
+
+// skill is a discovered skills/<dir>/SKILL.md artifact.
+type skill struct {
+	name  string
+	fm    map[string]string
+	empty bool
+}
+
+// agent is a discovered agents/<stem>.md artifact.
+type agent struct {
+	name string
+	fm   map[string]string
+}
+
+// claim is one narrative-ledger entry from claims.json.
+type claim struct {
+	ID        string     `json:"id"`
+	Source    string     `json:"source"`
+	Claim     string     `json:"claim"`
+	Reality   string     `json:"reality"`
+	Status    string     `json:"status"`
+	Check     claimCheck `json:"check"`
+	TrackedIn string     `json:"tracked_in"`
+}
+
+type claimCheck struct {
+	Type          string `json:"type"`
+	Path          string `json:"path"`
+	ExpectPresent *bool  `json:"expect_present"`
+}
+
+type ledgerFile struct {
+	NarrativeClaims []claim `json:"narrative_claims"`
+}
+
+// result holds everything the oracle discovered and decided, so that report
+// rendering and the process exit code are pure functions of it.
+type result struct {
+	skills      []skill
+	agents      []agent
+	presentDocs []string
+	refTokens   []string
+	errors      []string
+	warnings    []string
+	ledger      []claim
+}
+
+// parseFrontmatter parses a leading YAML frontmatter block (the text between
+// the opening "---" and the next "\n---") into a key->value map. It tolerates
+// folded scalars such as `description: >-` (the value is captured verbatim as
+// ">-", which is non-empty, so the key counts as present). It returns the
+// parsed map and the original content unchanged.
+func parseFrontmatter(content string) (map[string]string, string) {
+	if !strings.HasPrefix(content, "---") {
+		return map[string]string{}, content
+	}
+	rel := strings.Index(content[3:], "\n---")
+	if rel == -1 {
+		return map[string]string{}, content
+	}
+	end := 3 + rel
+	fm := map[string]string{}
+	for _, line := range strings.Split(content[3:end], "\n") {
+		if m := fmLineRe.FindStringSubmatch(line); m != nil {
+			fm[m[1]] = strings.TrimSpace(m[2])
+		}
+	}
+	return fm, content
+}
+
+// readFile reads a file as a string, mirroring Python's errors="replace": any
+// read error yields the empty string rather than aborting.
+func readFile(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// discoverSkills returns every subdir of skills/ that holds a SKILL.md, sorted
+// by directory name.
+func discoverSkills(root string) []skill {
+	var out []skill
+	entries, err := os.ReadDir(filepath.Join(root, "skills"))
+	if err != nil {
+		return out
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		sk := filepath.Join(root, "skills", name, "SKILL.md")
+		if !fileExists(sk) {
+			continue
+		}
+		fm, body := parseFrontmatter(readFile(sk))
+		out = append(out, skill{
+			name:  name,
+			fm:    fm,
+			empty: len(strings.TrimSpace(body)) < 50,
+		})
+	}
+	return out
+}
+
+// discoverAgents returns every agents/*.md artifact, sorted by file stem.
+func discoverAgents(root string) []agent {
+	var out []agent
+	matches, err := filepath.Glob(filepath.Join(root, "agents", "*.md"))
+	if err != nil {
+		return out
+	}
+	sort.Strings(matches)
+	for _, f := range matches {
+		fm, _ := parseFrontmatter(readFile(f))
+		stem := strings.TrimSuffix(filepath.Base(f), ".md")
+		out = append(out, agent{name: stem, fm: fm})
+	}
+	return out
+}
+
+// scanDocs concatenates the existing doc-set files and records which were
+// present, mirroring the reference (a leading "\n" before each file's text).
+func scanDocs(root string) (docText string, present []string) {
+	for _, rel := range docFiles {
+		p := filepath.Join(root, rel)
+		if fileExists(p) {
+			docText += "\n" + readFile(p)
+			present = append(present, rel)
+		}
+	}
+	return docText, present
+}
+
+// referencedTokens extracts the set of `/token` and /crosscheck:token tokens
+// referenced anywhere in the doc text, sorted.
+func referencedTokens(docText string) []string {
+	set := map[string]struct{}{}
+	for _, m := range slashTokRe.FindAllStringSubmatch(docText, -1) {
+		set[m[1]] = struct{}{}
+	}
+	for _, m := range xcheckRe.FindAllStringSubmatch(docText, -1) {
+		set[m[1]] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for t := range set {
+		out = append(out, t)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// documented reports whether an artifact name appears in the doc text in any
+// of the forms the reference recognises.
+func documented(name, docText string) bool {
+	return strings.Contains(docText, "`/"+name+"`") ||
+		strings.Contains(docText, "crosscheck:"+name) ||
+		strings.Contains(docText, "`"+name+"`") ||
+		strings.Contains(docText, "/"+name+" ")
+}
+
+// pyList renders a string slice the way Python repr does: ['a', 'b'].
+func pyList(items []string) string {
+	parts := make([]string, len(items))
+	for i, s := range items {
+		parts[i] = "'" + s + "'"
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// missingKeys returns the required keys absent from fm, sorted.
+func missingKeys(fm map[string]string) []string {
+	var missing []string
+	for _, k := range reqKeys {
+		if _, ok := fm[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	sort.Strings(missing)
+	return missing
+}
+
+// analyze runs every AUTO and LEDGER check against the plugin tree rooted at
+// root and returns the assembled result.
+func analyze(root string) result {
+	var r result
+	r.skills = discoverSkills(root)
+	r.agents = discoverAgents(root)
+	docText, present := scanDocs(root)
+	r.presentDocs = present
+	r.refTokens = referencedTokens(docText)
+
+	known := map[string]struct{}{}
+	for _, s := range r.skills {
+		known[s.name] = struct{}{}
+	}
+	for _, a := range r.agents {
+		known[a.name] = struct{}{}
+	}
+
+	// ---- AUTO 1: structural integrity ----
+	for _, s := range r.skills {
+		if missing := missingKeys(s.fm); len(missing) > 0 {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[structural] skill '%s': SKILL.md missing frontmatter keys %s", s.name, pyList(missing)))
+		}
+		if n := s.fm["name"]; n != "" && n != s.name {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[structural] skill dir '%s' != frontmatter name '%s'", s.name, n))
+		}
+		if s.empty {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[structural] skill '%s': SKILL.md is effectively empty", s.name))
+		}
+	}
+	for _, a := range r.agents {
+		if missing := missingKeys(a.fm); len(missing) > 0 {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[structural] agent '%s': missing frontmatter keys %s", a.name, pyList(missing)))
+		}
+		if n := a.fm["name"]; n != "" && n != a.name {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[structural] agent file '%s.md' != frontmatter name '%s'", a.name, n))
+		}
+	}
+
+	// ---- AUTO 2: phantom (doc references an artifact that does not exist) ----
+	for _, tok := range r.refTokens {
+		if _, ok := known[tok]; !ok {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[phantom] docs reference '/%s' but no skills/%s/ or agents/%s.md exists", tok, tok, tok))
+		}
+	}
+
+	// ---- AUTO 3: orphan (artifact exists but is referenced nowhere) ----
+	for _, s := range r.skills {
+		if !documented(s.name, docText) {
+			r.warnings = append(r.warnings, fmt.Sprintf(
+				"[orphan] skill '%s' ships but is not referenced in any doc %s", s.name, pyList(present)))
+		}
+	}
+	for _, a := range r.agents {
+		if !documented(a.name, docText) {
+			r.warnings = append(r.warnings, fmt.Sprintf(
+				"[orphan] agent '%s' ships but is not referenced in any doc", a.name))
+		}
+	}
+
+	// ---- AUTO 4: MCP tools claimed vs mcp-server source ----
+	mcpSrc := readMCPSource(root)
+	for _, m := range dafnyToolRe.FindAllStringSubmatch(docText, -1) {
+		tool := m[1]
+		if mcpSrc != "" && !strings.Contains(mcpSrc, tool) {
+			r.warnings = append(r.warnings, fmt.Sprintf(
+				"[mcp] README claims MCP tool '%s' but it's not found in mcp-server source", tool))
+		}
+	}
+
+	// ---- LEDGER: narrative claims ----
+	r.ledger = loadLedger(root)
+	for _, c := range r.ledger {
+		if c.Status == "unreviewed" {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[ledger] claim %s is UNREVIEWED — triage required", c.ID))
+		}
+		if c.Check.Type == "present_artifact" {
+			expect := true
+			if c.Check.ExpectPresent != nil {
+				expect = *c.Check.ExpectPresent
+			}
+			exists := fileExists(filepath.Join(root, c.Check.Path))
+			if exists != expect {
+				r.errors = append(r.errors, fmt.Sprintf(
+					"[ledger] claim %s auto-check failed: %s present=%v, expected_present=%v",
+					c.ID, c.Check.Path, exists, expect))
+			}
+		}
+	}
+
+	return r
+}
+
+// readMCPSource concatenates every .ts and .js file under mcp-server/, or ""
+// if the directory does not exist.
+func readMCPSource(root string) string {
+	dir := filepath.Join(root, "mcp-server")
+	if !fileExists(dir) {
+		return ""
+	}
+	var sb strings.Builder
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(path, ".ts") || strings.HasSuffix(path, ".js") {
+			sb.WriteString(readFile(path))
+		}
+		return nil
+	})
+	return sb.String()
+}
+
+// loadLedger reads conformance/claims.json, or returns nil if absent/unreadable.
+func loadLedger(root string) []claim {
+	data := readFile(filepath.Join(root, "conformance", "claims.json"))
+	if data == "" {
+		return nil
+	}
+	var lf ledgerFile
+	if err := json.Unmarshal([]byte(data), &lf); err != nil {
+		return nil
+	}
+	return lf.NarrativeClaims
+}
+
+// report renders the human-readable oracle report from a result.
+func report(r result) string {
+	var b strings.Builder
+	line := strings.Repeat("=", 72)
+	dash := strings.Repeat("-", 72)
+	fmt.Fprintln(&b, line)
+	fmt.Fprintln(&b, "CROSSCHECK CONFORMANCE / INVENTORY ORACLE")
+	fmt.Fprintln(&b, line)
+	fmt.Fprintf(&b, "skills discovered : %d\n", len(r.skills))
+	fmt.Fprintf(&b, "agents discovered : %d\n", len(r.agents))
+	fmt.Fprintf(&b, "docs scanned      : %s\n", pyList(r.presentDocs))
+	fmt.Fprintf(&b, "referenced tokens : %d\n", len(r.refTokens))
+	fmt.Fprintln(&b, dash)
+	fmt.Fprintf(&b, "ERRORS   : %d\n", len(r.errors))
+	for _, e := range r.errors {
+		fmt.Fprintf(&b, "  ✗ %s\n", e)
+	}
+	fmt.Fprintf(&b, "WARNINGS : %d\n", len(r.warnings))
+	for _, w := range r.warnings {
+		fmt.Fprintf(&b, "  ⚠ %s\n", w)
+	}
+	fmt.Fprintln(&b, dash)
+	fmt.Fprintf(&b, "NARRATIVE LEDGER (%d claims):\n", len(r.ledger))
+	for _, c := range r.ledger {
+		status := c.Status
+		if status == "" {
+			status = "?"
+		}
+		fmt.Fprintf(&b, "  • %s [%s]  %s\n", c.ID, status, c.Claim)
+		fmt.Fprintf(&b, "      reality: %s\n", c.Reality)
+		if c.TrackedIn != "" {
+			fmt.Fprintf(&b, "      tracked: %s\n", c.TrackedIn)
+		}
+	}
+	fmt.Fprintln(&b, line)
+	res := "PASS"
+	if len(r.errors) > 0 {
+		res = "FAIL"
+	}
+	fmt.Fprintf(&b, "RESULT: %s\n", res)
+	return b.String()
+}
+
+// defaultRoot resolves the scanned root: an explicit override arg, else the
+// "crosscheck" plugin dir relative to the current working directory. The oracle
+// is designed to be invoked from the repo root (`go run ./crosscheck/conformance`),
+// so the bare default points at the plugin dir there. If that directory is not
+// present (e.g. invoked from inside the plugin dir itself), it falls back to ".".
+func defaultRoot(args []string) string {
+	if len(args) > 1 {
+		return args[1]
+	}
+	if fileExists("crosscheck") {
+		return "crosscheck"
+	}
+	return "."
+}
+
+func main() {
+	root := defaultRoot(os.Args)
+	r := analyze(root)
+	fmt.Print(report(r))
+	if len(r.errors) > 0 {
+		os.Exit(1)
+	}
+}

--- a/crosscheck/conformance/main_test.go
+++ b/crosscheck/conformance/main_test.go
@@ -1,0 +1,323 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTree materialises a map of repo-relative paths to file contents under a
+// fresh temp dir and returns the root. Parent dirs are created as needed.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, content := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	return root
+}
+
+func hasMatch(items []string, substr string) bool {
+	for _, s := range items {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		wantName string // expected value of "name" key, "" if absent
+		wantDesc bool   // whether "description" key is present
+		wantKeys int
+	}{
+		{
+			name: "present_full",
+			content: "---\nname: reason\ndescription: does things\n---\n# body\n" +
+				"prose here that is long enough to not be empty",
+			wantName: "reason",
+			wantDesc: true,
+			wantKeys: 2,
+		},
+		{
+			name:     "absent_no_leading_marker",
+			content:  "# /assurance-probe\n\n**Layer**: 4\nlots of prose follows here",
+			wantName: "",
+			wantDesc: false,
+			wantKeys: 0,
+		},
+		{
+			name: "folded_scalar",
+			content: "---\nname: drt-oracle\ndescription: >-\n  A folded scalar value\n" +
+				"  spanning lines.\nargument-hint: \"[x]\"\n---\nbody text long enough",
+			wantName: "drt-oracle",
+			wantDesc: true,
+			wantKeys: 3, // name, description, argument-hint
+		},
+		{
+			name:     "no_closing_marker",
+			content:  "---\nname: broken\ndescription: x\nstill no closing fence",
+			wantName: "",
+			wantDesc: false,
+			wantKeys: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fm, body := parseFrontmatter(tc.content)
+			if body != tc.content {
+				t.Errorf("body mutated; want original content returned verbatim")
+			}
+			if got := fm["name"]; got != tc.wantName {
+				t.Errorf("name = %q, want %q", got, tc.wantName)
+			}
+			if _, ok := fm["description"]; ok != tc.wantDesc {
+				t.Errorf("description present = %v, want %v", ok, tc.wantDesc)
+			}
+			if len(fm) != tc.wantKeys {
+				t.Errorf("key count = %d, want %d (got %v)", len(fm), tc.wantKeys, fm)
+			}
+		})
+	}
+}
+
+func TestReferencedTokens(t *testing.T) {
+	doc := "see `/reason` and `/drt-oracle`, also use /crosscheck:lean-spec here. " +
+		"`not-a-token` lacks the slash; `/reason` repeats."
+	got := referencedTokens(doc)
+	want := []string{"drt-oracle", "lean-spec", "reason"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("referencedTokens = %v, want %v", got, want)
+	}
+}
+
+func TestDocumented(t *testing.T) {
+	doc := "intro `/reason` mid, and `byfuglien` agent, run /trace-execution now, " +
+		"plus crosscheck:lean-impl invocation."
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"reason", true},          // `/reason`
+		{"byfuglien", true},       // `byfuglien`
+		{"trace-execution", true}, // /trace-execution<space>
+		{"lean-impl", true},       // crosscheck:lean-impl
+		{"journal-context", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := documented(tc.name, doc); got != tc.want {
+				t.Errorf("documented(%q) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// baseTree returns a minimal-but-valid plugin tree: one well-formed skill, one
+// well-formed agent, both documented, plus an empty ledger. Callers mutate it.
+func baseTree() map[string]string {
+	return map[string]string{
+		"skills/reason/SKILL.md": "---\nname: reason\ndescription: reasons about code\n---\n" +
+			"# /reason\n\nA skill body long enough to clear the empty threshold easily.",
+		"agents/byfuglien.md": "---\nname: byfuglien\ndescription: orchestrates verification\n---\n" +
+			"# Byfuglien\n\nbody text.",
+		"README.md":               "Crosscheck ships `/reason` and the `byfuglien` orchestrator.",
+		"conformance/claims.json": `{"version":1,"narrative_claims":[]}`,
+	}
+}
+
+func TestPhantomDetection(t *testing.T) {
+	files := baseTree()
+	// Reference a skill that does not exist on disk.
+	files["README.md"] += " It also offers `/ghost-skill` which is not implemented."
+	r := analyze(writeTree(t, files))
+
+	if !hasMatch(r.errors, "[phantom]") || !hasMatch(r.errors, "ghost-skill") {
+		t.Errorf("expected phantom error for ghost-skill, got errors: %v", r.errors)
+	}
+	// The real artifacts must not produce phantom errors.
+	if hasMatch(r.errors, "reason") || hasMatch(r.errors, "byfuglien") {
+		t.Errorf("unexpected phantom error for real artifacts: %v", r.errors)
+	}
+}
+
+func TestOrphanDetection(t *testing.T) {
+	files := baseTree()
+	// Add a skill that no doc mentions.
+	files["skills/lonely/SKILL.md"] = "---\nname: lonely\ndescription: undocumented\n---\n" +
+		"# /lonely\n\nbody text long enough to not be empty at all."
+	r := analyze(writeTree(t, files))
+
+	if !hasMatch(r.warnings, "[orphan]") || !hasMatch(r.warnings, "lonely") {
+		t.Errorf("expected orphan warning for 'lonely', got warnings: %v", r.warnings)
+	}
+	// Orphan is a WARNING, never an ERROR.
+	if hasMatch(r.errors, "lonely") {
+		t.Errorf("orphan must not be an error: %v", r.errors)
+	}
+}
+
+func TestStructuralMissingFrontmatter(t *testing.T) {
+	files := baseTree()
+	// This mirrors the real assurance-probe defect: a SKILL.md that opens with a
+	// prose header instead of YAML frontmatter cannot register as a skill.
+	files["skills/probe/SKILL.md"] = "# /probe\n\n**Layer**: 4\n\nprose body, no frontmatter at all here."
+	r := analyze(writeTree(t, files))
+
+	if !hasMatch(r.errors, "[structural]") || !hasMatch(r.errors, "probe") ||
+		!hasMatch(r.errors, "missing frontmatter keys ['description', 'name']") {
+		t.Errorf("expected structural missing-frontmatter error for 'probe', got: %v", r.errors)
+	}
+}
+
+func TestStructuralNameMismatch(t *testing.T) {
+	files := baseTree()
+	files["skills/widget/SKILL.md"] = "---\nname: gadget\ndescription: mislabelled\n---\n" +
+		"# /widget\n\nbody text long enough to not be empty here."
+	r := analyze(writeTree(t, files))
+	if !hasMatch(r.errors, "skill dir 'widget' != frontmatter name 'gadget'") {
+		t.Errorf("expected dir/name mismatch error, got: %v", r.errors)
+	}
+}
+
+func TestStructuralEmptySkill(t *testing.T) {
+	files := baseTree()
+	files["skills/tiny/SKILL.md"] = "---\nname: tiny\ndescription: d\n---\n"
+	r := analyze(writeTree(t, files))
+	if !hasMatch(r.errors, "skill 'tiny': SKILL.md is effectively empty") {
+		t.Errorf("expected empty-skill error, got: %v", r.errors)
+	}
+}
+
+func boolp(b bool) *bool { return &b }
+
+func TestPresentArtifactLedger(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		expect    *bool
+		create    bool // whether to create the path under root
+		wantError bool
+	}{
+		{"absent_expected_absent", "agents/lowry.md", boolp(false), false, false},
+		{"present_expected_absent", "agents/here.md", boolp(false), true, true},
+		{"present_expected_present", "agents/here.md", boolp(true), true, false},
+		{"absent_expected_present", "agents/gone.md", boolp(true), false, true},
+		{"absent_default_present", "agents/gone.md", nil, false, true}, // default expect_present=true
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			files := baseTree()
+			if tc.create {
+				files[tc.path] = "placeholder"
+			}
+			expectField := "true"
+			if tc.expect != nil && !*tc.expect {
+				expectField = "false"
+			}
+			ledgerJSON := `{"version":1,"narrative_claims":[{"id":"C","claim":"c","reality":"r",` +
+				`"status":"known-gap","check":{"type":"present_artifact","path":"` + tc.path + `"`
+			if tc.expect != nil {
+				ledgerJSON += `,"expect_present":` + expectField
+			}
+			ledgerJSON += `}}]}`
+			files["conformance/claims.json"] = ledgerJSON
+
+			r := analyze(writeTree(t, files))
+			gotError := hasMatch(r.errors, "[ledger] claim C auto-check failed")
+			if gotError != tc.wantError {
+				t.Errorf("ledger error = %v, want %v (errors: %v)", gotError, tc.wantError, r.errors)
+			}
+		})
+	}
+}
+
+func TestUnreviewedLedgerFails(t *testing.T) {
+	files := baseTree()
+	files["conformance/claims.json"] = `{"version":1,"narrative_claims":[` +
+		`{"id":"C-NEW","claim":"c","reality":"r","status":"unreviewed","check":{"type":"manual"}}]}`
+	r := analyze(writeTree(t, files))
+	if !hasMatch(r.errors, "[ledger] claim C-NEW is UNREVIEWED") {
+		t.Errorf("expected UNREVIEWED ledger error, got: %v", r.errors)
+	}
+}
+
+func TestReportPassFail(t *testing.T) {
+	pass := report(result{})
+	if !strings.Contains(pass, "RESULT: PASS") {
+		t.Errorf("empty result should report PASS, got:\n%s", pass)
+	}
+	fail := report(result{errors: []string{"boom"}})
+	if !strings.Contains(fail, "RESULT: FAIL") {
+		t.Errorf("result with errors should report FAIL, got:\n%s", fail)
+	}
+}
+
+// TestGoldenRealTree pins the oracle's verdict against the actual crosscheck/
+// plugin tree (the parent of this package dir). It asserts the stable inventory
+// and the post-fix gate state: assurance-probe now has frontmatter, the
+// journal-context orphan WARNING remains a human decision, and all seven ledger
+// claims (five of them known-gap present_artifact/manual checks) hold.
+func TestGoldenRealTree(t *testing.T) {
+	root := ".." // package dir is crosscheck/conformance; plugin root is crosscheck/
+	if _, err := os.Stat(filepath.Join(root, "skills")); err != nil {
+		t.Skipf("real plugin tree not found at %s: %v", root, err)
+	}
+	r := analyze(root)
+
+	if len(r.skills) != 30 {
+		t.Errorf("skills discovered = %d, want 30", len(r.skills))
+	}
+	if len(r.agents) != 3 {
+		t.Errorf("agents discovered = %d, want 3", len(r.agents))
+	}
+	if len(r.refTokens) != 29 {
+		t.Errorf("referenced tokens = %d, want 29", len(r.refTokens))
+	}
+	if len(r.ledger) != 7 {
+		t.Fatalf("ledger claims = %d, want 7", len(r.ledger))
+	}
+
+	// The journal-context orphan is a known, deliberately-unresolved warning.
+	if !hasMatch(r.warnings, "journal-context") {
+		t.Errorf("expected journal-context orphan warning, got warnings: %v", r.warnings)
+	}
+
+	// The five known-gap claims must all be present in the ledger.
+	wantGaps := []string{"CLAIM-PHASE4", "CLAIM-MODES", "CLAIM-METHODOLOGY-COMMITTED",
+		"CLAIM-AUDITOR", "CLAIM-SELF-COVERAGE"}
+	for _, id := range wantGaps {
+		found := false
+		for _, c := range r.ledger {
+			if c.ID == id {
+				found = true
+				if c.Status != "known-gap" {
+					t.Errorf("claim %s status = %q, want known-gap", id, c.Status)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("missing expected ledger claim %s", id)
+		}
+	}
+
+	// Post-fix expectation: the gate is GREEN. assurance-probe now parses, and the
+	// present_artifact ledger checks (lowry/methodology/auditor absent) all hold,
+	// so there are no ERRORs.
+	if hasMatch(r.errors, "assurance-probe") {
+		t.Errorf("assurance-probe should have valid frontmatter post-fix; errors: %v", r.errors)
+	}
+	if len(r.errors) != 0 {
+		t.Errorf("expected RESULT PASS (0 errors) post-fix, got %d: %v", len(r.errors), r.errors)
+	}
+}

--- a/crosscheck/skills/assurance-probe/SKILL.md
+++ b/crosscheck/skills/assurance-probe/SKILL.md
@@ -1,3 +1,16 @@
+---
+name: assurance-probe
+description: >-
+  Measure test strength via mutation/vacuity/generator probes (rotation-based).
+  Layer 4 deterministic-strength check: parses the Failure condition clause of
+  each invariant, generates targeted source mutations, and runs covering
+  property-based tests against them, then adds vacuity (branch-coverage delta)
+  and generator-reachability probes. Emits a GitHub issue (<=3 findings per run)
+  with accept/reject/defer triage. Rotation-based, not per-PR — triggered
+  manually or via an /assurance-status recommendation. Triggers: "is this test
+  too weak", "run mutation probe", "check test adequacy", "test strength".
+argument-hint: "[optional: invariant ID or module to probe; default is the next in rotation]"
+---
 # /assurance-probe
 
 **Layer**: 4 (Deterministic strength)  

--- a/go.work
+++ b/go.work
@@ -1,0 +1,10 @@
+go 1.25
+
+// Repo-level Go workspace so the multi-module tree (each tool/plugin keeps its
+// own go.mod) is buildable from the repo root, e.g.
+//   go run ./crosscheck/conformance
+//   go test ./crosscheck/conformance/...
+use (
+	./crosscheck/conformance
+	./tools/claude-github-app
+)


### PR DESCRIPTION
## What this is

The missing **conformance / inventory oracle** for Crosscheck: a mechanical trap that verifies *what the docs claim Crosscheck ships* against *what the filesystem actually contains*. It is the existing invariant↔test coverage-gate pattern lifted one level up to **docs ↔ artifacts** — the first **trunk-level** self-check (the plugin previously verified only its leaves: three helper functions under `docs/invariants/`).

Implemented in **Go, stdlib-only**, as a self-contained module at `crosscheck/conformance/` (following the `tools/claude-github-app/` idioms — table-driven tests, stdlib-first). Behavior is a faithful port of the authoritative Python reference; `claims.json` is reused verbatim.

## Run / build

```bash
go run ./crosscheck/conformance              # from repo root, defaults to scanning crosscheck/
go run ./crosscheck/conformance crosscheck   # explicit root
go build -o conformance ./crosscheck/conformance
go test ./crosscheck/conformance/...
```

A repo-root `go.work` was added so the nested module resolves when invoked from the repo root (it lists both the new module and the existing `tools/claude-github-app` so that module's in-dir workflow is unaffected — verified its build + tests still pass under the workspace).

## Two layers

- **AUTO (deterministic, fails CI on ERROR):** *structural* frontmatter integrity, *phantom* doc references, *orphan* artifacts (WARN), *MCP*-tool claims (WARN).
- **LEDGER (`claims.json`, reviewed not auto-proved):** narrative claims, each with a review `status` and where possible a self-invalidating `present_artifact` check that **re-fires the day reality changes** (e.g. `agents/lowry.md expect_present:false` flips to ERROR when Phase 4 ships). `status:"unreviewed"` fails CI to force triage.

## Findings on the current tree (plugin v2.5.1)

Verification target reproduced **before** the fix → `RESULT: FAIL` (exit 1):

- **ERROR — `[structural] skill 'assurance-probe': SKILL.md missing frontmatter keys ['description', 'name']`**. `skills/assurance-probe/SKILL.md` opened with a prose `# /assurance-probe` header and no YAML frontmatter, so it could not register as a loadable skill — yet `agents/byfuglien.md` routes "test strength" requests to `/assurance-probe`. This held the gate RED.
- **WARNING — `[orphan] skill 'journal-context' ships but is not referenced in any doc`**.
- **LEDGER — 7 narrative claims** print, including 2 reviewed (`CLAIM-LAYERS`, `CLAIM-ADDORCH-TERMINAL`) and 5 `known-gap` entries:
  - `CLAIM-PHASE4` — Phase 4 gated-implementation agent (designed, not shipped)
  - `CLAIM-MODES` — bootstrap/add/transitional operating modes (not wired)
  - `CLAIM-METHODOLOGY-COMMITTED` — canonical ADD methodology docs (never committed)
  - `CLAIM-AUDITOR` — Phase 5 Auditor agent (designed, not shipped)
  - `CLAIM-SELF-COVERAGE` — trunk-level self-coverage (this oracle is the first)

Inventory counts: **30 skills, 3 agents, 29 referenced tokens, 5 docs scanned.**

## The one fix applied (scoped)

Added `name` / `description` / `argument-hint` frontmatter to `skills/assurance-probe/SKILL.md`, matching sibling `assurance-*` skills. The `description` is synthesized from the file's existing prose plus byfuglien's one-line routing description (*"Measure test strength via mutation/vacuity/generator probes (rotation-based)"*) including its trigger phrases. **The skill body is otherwise unchanged.**

After the fix the oracle prints `RESULT: PASS` (exit 0).

### Deliberately left as-is (human decisions, not resolved here)

- The `journal-context` **orphan WARNING** — document or de-scope is a maintainer call.
- All **ledger `known-gap` entries** — tracked in the epic; out of scope for this PR.

## Tests

`go test ./crosscheck/conformance/...` — table-driven coverage of the frontmatter parser (present / absent / folded-scalar / no-closing cases), phantom detection, orphan detection, structural checks (missing-frontmatter / name-mismatch / empty), the `present_artifact` ledger check (all four expect/actual combinations + default), the unreviewed-ledger gate, and a **golden test pinned against the real plugin tree** (asserts the inventory counts, the `journal-context` orphan, the 5 known-gaps, and the post-fix GREEN gate).

## Suggested CI wiring

```yaml
# .github/workflows/conformance.yml  (sketch)
jobs:
  conformance:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-go@v5
        with: { go-version: '1.25' }
      - run: go run ./crosscheck/conformance crosscheck
      - run: go test ./crosscheck/conformance/...
```

## Out of scope

No Phase 4 agent, no operating-mode system, no related issues filed — those are tracked separately. This PR is the conformance oracle plus the single `assurance-probe` frontmatter fix.

**Do not merge** — merge is the maintainer's ratification gate.

https://claude.ai/code/session_01BFKngrwLgFhbSaErLiJ2J6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFKngrwLgFhbSaErLiJ2J6)_