### PR TITLE
feat(crosscheck): document journal-context and track ledger gaps in conformance oracle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Crosscheck plugin. Crosschecks Claude's code claims using Dafny formal verificat
 - **Lean executable-model + DRT-oracle pipeline** (`crosscheck/skills/`): `/informal-spec`, `/lean-spec`, `/lean-impl`, `/correspondence-review`, `/drt-oracle`
 - **Spec management & adequacy skills** (`crosscheck/skills/`): `/check-regressions`, `/suggest-specs`, `/rationale`, `/audit-spec-coverage`, `/audit-invariant-consistency`
 - **Semi-formal reasoning skills** (`crosscheck/skills/`): `/reason`, `/compare-patches`, `/locate-fault`, `/trace-execution`
+- **Repository context skill** (`crosscheck/skills/`): `/journal-context` (deterministic walk of every `JOURNAL.md` from a path up to the repo root; load the narrative record before non-trivial design work)
 - **Orchestrator agents** (`crosscheck/agents/`): `byfuglien` (implementation chain, sequential router), `hellebuyck` (specification chain, sequential router), `add-orchestrator` (ADD methodology workflow runner; parallel subagent dispatch + batched audit triage; drives spec → approved invariants ready for implementation)
 
 ### awesome-copilot (`awesome-copilot/`)

--- a/crosscheck/README.md
+++ b/crosscheck/README.md
@@ -88,6 +88,8 @@ The persona table above maps every skill to its orchestrator and (where applicab
 
 **Assurance hierarchy & governance** — onboard a repo, audit its reach on the ladder, draft acceptance oracles, run the round-trip intent check, measure test strength via mutation probes (`/assurance-probe`, Phase 1 – experimental), and keep governance notes from rotting.
 
+**Repository context** — `/journal-context` walks every `JOURNAL.md` from a path up to the repo root (deterministic, read-only), loading the narrative record before non-trivial design work.
+
 → Full skill catalogue with trigger phrases at [`./docs/skills.md`](./docs/skills.md). For the assurance flow specifically, see [`./docs/assurance-hierarchy.md`](./docs/assurance-hierarchy.md).
 
 ### Worked examples

--- a/crosscheck/conformance/README.md
+++ b/crosscheck/conformance/README.md
@@ -40,17 +40,22 @@ Exit 0 = PASS, 1 = FAIL (any AUTO error, or any `unreviewed` ledger claim, or a
   review `status`, and where possible an auto-check that **re-fires if reality
   changes** (e.g. `agents/lowry.md expect_present:false` flips to FAIL the day
   Phase 4 ships, forcing the ledger to be updated). `status:"unreviewed"` fails
-  CI to force triage of any new claim.
+  CI to force triage of any new claim. A `status:"known-gap"` entry must carry a
+  `tracked_in` link to its section in the ledger-gap roadmap
+  ([`../docs/add/roadmap.md`](../docs/add/roadmap.md)); a known-gap with no link
+  also fails CI, so a "known" gap can never be tracked nowhere.
 
 ## First-run findings (2026-05-30, plugin v2.5.1)
 
 - **ERROR** `assurance-probe` — `SKILL.md` had no frontmatter; couldn't load as a
   skill, yet `byfuglien` routes to it. **Fixed in the PR that introduced this
   oracle** (frontmatter added; this is why the gate is now GREEN).
-- **WARN** `journal-context` — ships but is undocumented in the user-facing doc
-  set (decide: document or de-scope). Left as-is — a human decision.
+- **WARN** `journal-context` — was undocumented in the user-facing doc set; now
+  documented in the README skills overview and the top-level `CLAUDE.md`, so the
+  orphan warning clears.
 - **LEDGER known-gaps** — Phase 4 agent, operating modes, committed methodology,
-  Phase 5 auditor, self-coverage. See `claims.json`; tracked in the epic.
+  Phase 5 auditor, self-coverage. See `claims.json`; each is tracked in the
+  ledger-gap roadmap ([`../docs/add/roadmap.md`](../docs/add/roadmap.md)).
 
 ## Wire to CI (suggested)
 

--- a/crosscheck/conformance/claims.json
+++ b/crosscheck/conformance/claims.json
@@ -8,7 +8,9 @@
       "claim": "Six layers of correctness checks, four shipping today.",
       "reality": "Layers 1,4,5,6 have shipping skills; Layers 2 (compilation correctness) and 3 (contract-graph) do not. README discloses this honestly ('four of them are shipping today').",
       "status": "reviewed-disclosed",
-      "check": {"type": "manual"},
+      "check": {
+        "type": "manual"
+      },
       "tracked_in": ""
     },
     {
@@ -17,7 +19,9 @@
       "claim": "add-orchestrator drives spec -> approved invariant docs READY FOR IMPLEMENTATION.",
       "reality": "Accurate. The agent explicitly stops at the routing recommendation and disclaims implementation-correctness closure. NOT drift.",
       "status": "reviewed-accurate",
-      "check": {"type": "manual"},
+      "check": {
+        "type": "manual"
+      },
       "tracked_in": ""
     },
     {
@@ -26,8 +30,12 @@
       "claim": "ADD includes a Phase 4 gated-implementation loop that drives code to green within three legal commit shapes.",
       "reality": "Designed, not shipped. No implementing agent exists (grep agents/: byfuglien, hellebuyck, add-orchestrator only). This is the run-to-green capability the user expected.",
       "status": "known-gap",
-      "check": {"type": "present_artifact", "path": "agents/lowry.md", "expect_present": false},
-      "tracked_in": "ISSUE#2 / phase4-agent-handoff.md"
+      "check": {
+        "type": "present_artifact",
+        "path": "agents/lowry.md",
+        "expect_present": false
+      },
+      "tracked_in": "docs/add/roadmap.md#claim-phase4"
     },
     {
       "id": "CLAIM-MODES",
@@ -35,8 +43,10 @@
       "claim": "Three operating modes (bootstrap / add / transitional) with module-level mode tags honoured by skills.",
       "reality": "Not wired. add-orchestrator hardwires the signed-off-spec path (Step 1 requires >=10 RFC-2119 keywords) and reads no mode tags. Legacy hardening and empty-repo greenfield have no orchestrated entrypoint.",
       "status": "known-gap",
-      "check": {"type": "manual"},
-      "tracked_in": "ISSUE#3"
+      "check": {
+        "type": "manual"
+      },
+      "tracked_in": "docs/add/roadmap.md#claim-modes"
     },
     {
       "id": "CLAIM-METHODOLOGY-COMMITTED",
@@ -44,8 +54,12 @@
       "claim": "The canonical ADD methodology (methodology.md, glossary.md, the ADRs) lives in the repo.",
       "reality": "Never committed. Only docs/add/README.md, JOURNAL.md, orchestrator-improvements.md shipped. The phase/mode/diff-classification design exists only in design conversation + the phase4-agent-handoff.md brief.",
       "status": "known-gap",
-      "check": {"type": "present_artifact", "path": "docs/add/methodology.md", "expect_present": false},
-      "tracked_in": "ISSUE#1 (epic)"
+      "check": {
+        "type": "present_artifact",
+        "path": "docs/add/methodology.md",
+        "expect_present": false
+      },
+      "tracked_in": "docs/add/roadmap.md#claim-methodology-committed"
     },
     {
       "id": "CLAIM-AUDITOR",
@@ -53,17 +67,23 @@
       "claim": "A Phase 5 Auditor agent renders settled/active/drifted verdicts on every artifact.",
       "reality": "Designed, not shipped. No auditor agent exists.",
       "status": "known-gap",
-      "check": {"type": "present_artifact", "path": "agents/auditor.md", "expect_present": false},
-      "tracked_in": "ISSUE#5"
+      "check": {
+        "type": "present_artifact",
+        "path": "agents/auditor.md",
+        "expect_present": false
+      },
+      "tracked_in": "docs/add/roadmap.md#claim-auditor"
     },
     {
       "id": "CLAIM-SELF-COVERAGE",
       "source": "docs/invariants/",
       "claim": "Crosscheck applies its own assurance machinery to itself.",
-      "reality": "docs/invariants/ covers three helper functions (parseDafnyOutput, shouldExclude, extractDifficultyMetrics) — the plugin verified its leaves, not its trunk (orchestrators, gates, workflow). This conformance oracle is the first trunk-level check.",
+      "reality": "docs/invariants/ covers three helper functions (parseDafnyOutput, shouldExclude, extractDifficultyMetrics) \u2014 the plugin verified its leaves, not its trunk (orchestrators, gates, workflow). This conformance oracle is the first trunk-level check.",
       "status": "known-gap",
-      "check": {"type": "manual"},
-      "tracked_in": "ISSUE#1 (epic)"
+      "check": {
+        "type": "manual"
+      },
+      "tracked_in": "docs/add/roadmap.md#claim-self-coverage"
     }
   ]
 }

--- a/crosscheck/conformance/main.go
+++ b/crosscheck/conformance/main.go
@@ -323,6 +323,10 @@ func analyze(root string) result {
 			r.errors = append(r.errors, fmt.Sprintf(
 				"[ledger] claim %s is UNREVIEWED — triage required", c.ID))
 		}
+		if c.Status == "known-gap" && strings.TrimSpace(c.TrackedIn) == "" {
+			r.errors = append(r.errors, fmt.Sprintf(
+				"[ledger] claim %s is a known-gap with no tracked_in link", c.ID))
+		}
 		if c.Check.Type == "present_artifact" {
 			expect := true
 			if c.Check.ExpectPresent != nil {

--- a/crosscheck/conformance/main_test.go
+++ b/crosscheck/conformance/main_test.go
@@ -252,6 +252,26 @@ func TestUnreviewedLedgerFails(t *testing.T) {
 	}
 }
 
+func TestKnownGapNeedsTracking(t *testing.T) {
+	// A known-gap with no tracked_in link fails CI.
+	files := baseTree()
+	files["conformance/claims.json"] = `{"version":1,"narrative_claims":[` +
+		`{"id":"C-GAP","claim":"c","reality":"r","status":"known-gap","check":{"type":"manual"}}]}`
+	r := analyze(writeTree(t, files))
+	if !hasMatch(r.errors, "claim C-GAP is a known-gap with no tracked_in link") {
+		t.Errorf("expected known-gap-without-tracking error, got: %v", r.errors)
+	}
+
+	// The same gap with a tracked_in link is clean.
+	files["conformance/claims.json"] = `{"version":1,"narrative_claims":[` +
+		`{"id":"C-GAP","claim":"c","reality":"r","status":"known-gap",` +
+		`"tracked_in":"docs/add/roadmap.md#c-gap","check":{"type":"manual"}}]}`
+	r = analyze(writeTree(t, files))
+	if hasMatch(r.errors, "no tracked_in link") {
+		t.Errorf("known-gap with tracking should not error, got: %v", r.errors)
+	}
+}
+
 func TestReportPassFail(t *testing.T) {
 	pass := report(result{})
 	if !strings.Contains(pass, "RESULT: PASS") {
@@ -281,16 +301,17 @@ func TestGoldenRealTree(t *testing.T) {
 	if len(r.agents) != 3 {
 		t.Errorf("agents discovered = %d, want 3", len(r.agents))
 	}
-	if len(r.refTokens) != 29 {
-		t.Errorf("referenced tokens = %d, want 29", len(r.refTokens))
+	if len(r.refTokens) != 30 {
+		t.Errorf("referenced tokens = %d, want 30", len(r.refTokens))
 	}
 	if len(r.ledger) != 7 {
 		t.Fatalf("ledger claims = %d, want 7", len(r.ledger))
 	}
 
-	// The journal-context orphan is a known, deliberately-unresolved warning.
-	if !hasMatch(r.warnings, "journal-context") {
-		t.Errorf("expected journal-context orphan warning, got warnings: %v", r.warnings)
+	// journal-context is now documented in the README skills overview, so it must
+	// no longer be flagged as an orphan.
+	if hasMatch(r.warnings, "journal-context") {
+		t.Errorf("journal-context should be documented, but is still flagged as an orphan: %v", r.warnings)
 	}
 
 	// The five known-gap claims must all be present in the ledger.

--- a/crosscheck/docs/add/roadmap.md
+++ b/crosscheck/docs/add/roadmap.md
@@ -1,0 +1,87 @@
+# Crosscheck ledger-gap roadmap (the "epic")
+
+This is the tracked home for the **known gaps** recorded in the conformance
+oracle's ledger ([`../../conformance/claims.json`](../../conformance/claims.json)).
+The oracle classifies a narrative claim as `known-gap` when the docs over-promise
+and the work is pending. A gap that is "known" but tracked nowhere is exactly the
+`plausible ≠ correct` failure mode the oracle exists to catch — so every
+`known-gap` entry in `claims.json` carries a `tracked_in` link pointing at a
+section below, and the oracle **fails CI** if a `known-gap` has no such link (see
+`analyze` in [`../../conformance/main.go`](../../conformance/main.go)).
+
+Each section records: the claim, current reality, the disposition / next step,
+and — where one exists — the self-invalidating `present_artifact` check that
+flips the oracle from PASS to FAIL the day the gap is closed (so the ledger
+re-fires and forces re-triage rather than silently going stale).
+
+These gaps are intentionally **not** scheduled by this documentation pass; this
+doc gives them a durable in-repo home and makes the ledger's `tracked_in` links
+resolve to something real (they previously pointed at `ISSUE#…` placeholders that
+were never filed). Closing any gap is separate, release-triggering work.
+
+---
+
+## CLAIM-PHASE4
+
+- **Claim:** ADD includes a Phase 4 gated-implementation loop that drives code to
+  green within three legal commit shapes.
+- **Reality:** Designed, not shipped. No implementing agent exists — `agents/`
+  holds only `byfuglien`, `hellebuyck`, and `add-orchestrator`.
+- **Self-invalidating check:** `present_artifact` watches `agents/lowry.md` with
+  `expect_present: false`. The day a Phase 4 agent lands at that path the oracle
+  goes RED, forcing this claim to be re-reviewed and re-classified.
+- **Disposition:** Tracked, unscheduled. When picked up: ship the Phase 4 agent
+  (`agents/lowry.md`), wire it after `add-orchestrator`'s routing recommendation
+  (`CLAIM-ADDORCH-TERMINAL` is accurate today — the orchestrator stops at the
+  recommendation and disclaims implementation closure), and flip this entry to
+  `reviewed-accurate`.
+
+## CLAIM-MODES
+
+- **Claim:** Three operating modes (bootstrap / add / transitional) with
+  module-level mode tags honoured by skills.
+- **Reality:** Not wired. `add-orchestrator` hardwires the signed-off-spec path
+  (Step 1 requires ≥10 RFC-2119 keywords) and reads no mode tags; legacy
+  hardening and empty-repo greenfield have no orchestrated entrypoint.
+- **Self-invalidating check:** none — no single artifact cleanly represents the
+  mode system. Re-review manually when the orchestrator gains mode selection.
+- **Disposition:** Tracked, unscheduled. When picked up: introduce mode selection
+  in `agents/add-orchestrator.md`, document the three modes, and flip this entry
+  to `reviewed-accurate`. Until then it stays a disclosed gap.
+
+## CLAIM-METHODOLOGY-COMMITTED
+
+- **Claim:** The canonical ADD methodology (`methodology.md`, `glossary.md`, the
+  ADRs) lives in the repo.
+- **Reality:** Never committed. Only `docs/add/README.md`, `docs/add/JOURNAL.md`,
+  and `docs/add/orchestrator-improvements.md` shipped (plus this roadmap).
+- **Self-invalidating check:** `present_artifact` watches `docs/add/methodology.md`
+  with `expect_present: false`. Note this roadmap is **not** `methodology.md`: it
+  tracks the gaps, it is not the canonical methodology, so it neither satisfies
+  this claim nor trips the check.
+- **Disposition:** Tracked, unscheduled. When picked up: commit
+  `docs/add/methodology.md` as the canonical methodology, then flip this entry to
+  `reviewed-accurate`.
+
+## CLAIM-AUDITOR
+
+- **Claim:** A Phase 5 Auditor agent renders settled / active / drifted verdicts
+  on every artifact.
+- **Reality:** Designed, not shipped. No auditor agent exists.
+- **Self-invalidating check:** `present_artifact` watches `agents/auditor.md` with
+  `expect_present: false`. Lands RED the day an auditor agent ships at that path.
+- **Disposition:** Tracked, unscheduled. When picked up: ship the auditor agent
+  (`agents/auditor.md`) and flip this entry to `reviewed-accurate`.
+
+## CLAIM-SELF-COVERAGE
+
+- **Claim:** Crosscheck applies its own assurance machinery to itself.
+- **Reality:** Only the leaves are verified — `docs/invariants/` covers three
+  helper functions (`parseDafnyOutput`, `shouldExclude`, `extractDifficultyMetrics`).
+  The conformance oracle is the **first** trunk-level self-check; orchestrators,
+  gates, and the workflow remain unverified.
+- **Self-invalidating check:** none — coverage is a spectrum, not a single
+  artifact. Re-review manually as trunk coverage grows.
+- **Disposition:** Tracked, unscheduled. The conformance oracle is the first
+  increment. As orchestrator/gate self-checks are added, narrow this claim's
+  `reality` toward `reviewed-disclosed` and eventually `reviewed-accurate`.


### PR DESCRIPTION
Resolve the two items PR #214 deliberately deferred to the maintainer:

- Document the /journal-context skill in crosscheck/README.md and the
  top-level CLAUDE.md, clearing the conformance oracle's orphan WARNING
  (and adding it to the referenced-token set).
- Give the 5 ledger known-gaps a real tracked home: add docs/add/roadmap.md
  (the "epic") with one anchored section per CLAIM-*, repoint each known-gap's
  tracked_in in claims.json from the never-filed ISSUE# placeholders to that
  roadmap, and make the oracle fail CI on a known-gap with no tracked_in link
  (self-enforcing, so a "known" gap can never be tracked nowhere).

Update the golden test: journal-context is no longer an orphan, referenced
tokens are now 30, and add a case for the known-gap -> tracked_in rule.

https://claude.ai/code/session_018QN4ZedBTfSJtotxeH6czY